### PR TITLE
✨(components) add Material Icons filled support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/modifiers": "9.0.0",
     "@dnd-kit/sortable": "10.0.0",
+    "@fontsource/material-icons": "5.2.5",
     "@gouvfr-lasuite/integration": "1.0.2",
     "@openfun/cunningham-react": "3.0.0",
     "@types/node": "22.10.7",

--- a/src/components/icon/Icon.stories.tsx
+++ b/src/components/icon/Icon.stories.tsx
@@ -1,0 +1,164 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "./Icon";
+import { IconSize, IconType } from "./types";
+
+const meta: Meta<typeof Icon> = {
+  title: "Components/Icon",
+  component: Icon,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    name: {
+      control: "text",
+      description: "The name of the Material Icon to display",
+    },
+    size: {
+      control: { type: "select" },
+      options: ["small", "medium", "large", "xlarge"],
+      description: "The size of the icon",
+    },
+    color: {
+      control: "color",
+      description: "Custom color for the icon",
+    },
+    clickable: {
+      control: "boolean",
+      description: "Whether the icon should be clickable",
+    },
+    onClick: {
+      action: "clicked",
+      description: "Click handler for the icon",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic icon story
+export const Default: Story = {
+  args: {
+    name: "home",
+    size: IconSize.MEDIUM,
+  },
+};
+
+// Different sizes
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+      <Icon name="home" size={IconSize.X_SMALL} />
+      <Icon name="home" size={IconSize.SMALL} />
+      <Icon name="home" size={IconSize.MEDIUM} />
+      <Icon name="home" size={IconSize.LARGE} />
+      <Icon name="home" size={IconSize.X_LARGE} />
+      <Icon name="home" size={84} />
+    </div>
+  ),
+};
+
+export const Outlined: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+      <Icon name="home" type={IconType.OUTLINED} />
+      <Icon name="check_circle" type={IconType.OUTLINED} />
+      <Icon name="info" type={IconType.OUTLINED} />
+    </div>
+  ),
+};
+
+// Different colors
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+      <Icon name="favorite" color="#e74c3c" />
+      <Icon name="star" color="#f39c12" />
+      <Icon name="check_circle" color="#27ae60" />
+      <Icon name="info" color="#3498db" />
+      <Icon name="warning" color="#9b59b6" />
+    </div>
+  ),
+};
+
+// Clickable icons
+export const Clickable: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+      <Icon
+        name="favorite"
+        clickable
+        onClick={() => alert("Favorite clicked!")}
+        color="#e74c3c"
+      />
+      <Icon
+        name="delete"
+        clickable
+        onClick={() => alert("Delete clicked!")}
+        color="#e74c3c"
+      />
+      <Icon
+        name="edit"
+        clickable
+        onClick={() => alert("Edit clicked!")}
+        color="#3498db"
+      />
+      <Icon
+        name="share"
+        clickable
+        onClick={() => alert("Share clicked!")}
+        color="#27ae60"
+      />
+    </div>
+  ),
+};
+
+// Common icons showcase
+export const CommonIcons: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(6, 1fr)",
+        gap: "16px",
+      }}
+    >
+      <Icon name="home" />
+      <Icon name="search" />
+      <Icon name="settings" />
+      <Icon name="person" />
+      <Icon name="notifications" />
+      <Icon name="menu" />
+      <Icon name="close" />
+      <Icon name="check" />
+      <Icon name="add" />
+      <Icon name="remove" />
+      <Icon name="edit" />
+      <Icon name="delete" />
+      <Icon name="favorite" />
+      <Icon name="star" />
+      <Icon name="share" />
+      <Icon name="download" />
+      <Icon name="upload" />
+      <Icon name="refresh" />
+      <Icon name="info" />
+      <Icon name="warning" />
+      <Icon name="error" />
+      <Icon name="help" />
+      <Icon name="visibility" />
+      <Icon name="visibility_off" />
+      <Icon name="lock" />
+      <Icon name="unlock" />
+    </div>
+  ),
+};
+
+// Interactive playground
+export const Playground: Story = {
+  args: {
+    name: "home",
+    size: IconSize.MEDIUM,
+    clickable: false,
+  },
+};

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import clsx from "clsx";
+import { IconSize, IconType } from "./types";
+
+export type IconProps = {
+  /**
+   * The name of the Material Icon to display
+   */
+  name: string;
+
+  /**
+   * The type of the icon
+   */
+  type?: IconType;
+
+  /**
+   * The size of the icon
+   */
+  size?: IconSize | number;
+  /**
+   * Custom CSS class name
+   */
+  className?: string;
+  /**
+   * Custom color for the icon
+   */
+  color?: string;
+
+  /**
+   * Additional props to pass to the span element
+   */
+  [key: string]: unknown;
+};
+
+export const Icon: React.FC<IconProps> = ({
+  name,
+  size,
+  className,
+  color,
+
+  type = IconType.FILLED,
+  ...props
+}) => {
+  const iconClasses = clsx(
+    ``,
+    {
+      [`icon--${size}`]: size !== undefined,
+      [`material-icons-${type}`]: type !== IconType.OUTLINED,
+      "material-icons": type === IconType.OUTLINED,
+    },
+    className
+  );
+
+  const style = {
+    color: color,
+    fontSize: typeof size === "number" ? `${size}px` : undefined,
+  };
+
+  return (
+    <span className={iconClasses} style={style} {...props}>
+      {name}
+    </span>
+  );
+};

--- a/src/components/icon/index.scss
+++ b/src/components/icon/index.scss
@@ -1,0 +1,46 @@
+.material-icons-filled {
+  font-family: "Material Icons", sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizelegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: "liga";
+}
+
+// Icon sizes
+.icon--xsmall {
+  font-size: 11px;
+}
+
+.icon--small {
+  font-size: 16px;
+}
+
+.icon--medium {
+  font-size: 24px;
+}
+
+.icon--large {
+  font-size: 32px;
+}
+
+.icon--xlarge {
+  font-size: 48px;
+}

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -1,0 +1,3 @@
+export * from "./Icon";
+export * from "./types";
+export * from "./utils";

--- a/src/components/icon/types.ts
+++ b/src/components/icon/types.ts
@@ -1,0 +1,12 @@
+export enum IconSize {
+  X_SMALL = "xsmall",
+  SMALL = "small",
+  MEDIUM = "medium",
+  LARGE = "large",
+  X_LARGE = "xlarge",
+}
+
+export enum IconType  {
+  OUTLINED = "outlined",
+  FILLED = "filled",
+};

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -1,0 +1,26 @@
+import { IconSize } from "./types";
+
+export const iconSizeMap: Record<IconSize, number> = {
+  [IconSize.X_SMALL]: 11,
+  [IconSize.SMALL]: 16,
+  [IconSize.MEDIUM]: 24,
+  [IconSize.LARGE]: 32,
+  [IconSize.X_LARGE]: 40,
+};
+
+export const containerSizeMap: Record<IconSize, number> = {
+  [IconSize.X_SMALL]: 16,
+  [IconSize.SMALL]: 24,
+  [IconSize.MEDIUM]: 32,
+  [IconSize.LARGE]: 40,
+  [IconSize.X_LARGE]: 48,
+};
+
+export const getContainerSize = (iconSize: IconSize): number => {
+  return containerSizeMap[iconSize] ?? 24;
+};
+
+
+export const getIconSize = (iconSize: IconSize): number => {
+  return iconSizeMap[iconSize] ?? 24;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from "./components/tabs";
 export * from "./components/tree-view";
 export * from "./components/form/label/label";
 export * from "./components/badge";
+export * from "./components/icon";
 export * from "./hooks/useResponsive";
 export * from "./components/share";
 export * from "./components/users";

--- a/src/library.scss
+++ b/src/library.scss
@@ -36,4 +36,6 @@
 @use "./components/share/modal/share-modal";
 @use "./components/modal";
 @use "./components/badge";
+@use "./components/icon";
 @use "./assets/fonts/Marianne/Marianne-font.css";
+@use "@fontsource/material-icons";

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,6 +890,11 @@
   resolved "https://registry.yarnpkg.com/@fontsource/material-icons-outlined/-/material-icons-outlined-5.1.1.tgz#3a659277f5029fb1ea5f64739d7ef48fd2112a8e"
   integrity sha512-HjWe3anHu9RptoAvm2UF6MPXkwsbFbH+vkg48GRIhXPsXyfmZteGHVFZpPxaZnakrmnLXDxUnnKSj7zzqk+Rhg==
 
+"@fontsource/material-icons@5.2.5":
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@fontsource/material-icons/-/material-icons-5.2.5.tgz#cdb9dd23c0da4b021c866dc529ed4c203414ec3c"
+  integrity sha512-9k0LBRVgResIeD+vC/epYmm/awN2k2L8twwEtUWQ3FHluMi+7PbISOpXqksvfqPn9FJy4/KEeWOhFTR/SrbhNw==
+
 "@formatjs/ecma402-abstract@2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.2.tgz#0ee291effe7ee2c340742a6c95d92eacb5e6c00a"


### PR DESCRIPTION
This commit introduces support for Material Icons filled version in the project. It includes the addition of the `@fontsource/material-icons` package to the dependencies, along with the creation of an `Icon` component that allows for customizable icons with various sizes and colors. The associated styles and utility functions for handling icon sizes have also been implemented, enhancing the overall icon functionality within the application.