### PR TITLE
👷(version) re add changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,3 @@ db.sqlite3
 *.iml
 .devcontainer   
 node_modules
-.changeset


### PR DESCRIPTION
We remove the changeset config because we were not using it for the changleog, but we need it for version releases.