### PR TITLE
✅(types) add test type to ensure no translation keys are missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@dnd-kit/sortable": "10.0.0",
     "@fontsource/material-icons": "5.2.5",
     "@gouvfr-lasuite/integration": "1.0.2",
-    "@openfun/cunningham-react": "3.2.2",
+    "@openfun/cunningham-react": "3.2.3",
     "@types/node": "22.10.7",
     "clsx": "2.1.1",
     "cmdk": "1.0.4",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -15,7 +15,6 @@
         "title": "Pending invitations"
       },
       "members": {
-        "title": "Members",
         "title_plural": "Shared between {count} people",
         "title_singular": "Shared between {count} person",
         "load_more": "Show more "

--- a/src/types/translation.test.ts
+++ b/src/types/translation.test.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { locales } from ":/locales/Locale";
+
+/** Translation type testing */
+
+import { ExtractTranslationKeys } from "./translations";
+
+/**
+ * Want to understand what the hell is that ? Read this:
+ * https://github.com/Microsoft/TypeScript/issues/27024#issuecomment-421529650
+ */
+type AssertIsStrictEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2) ?
+  true : { error: "Types are not equal"; expected: X; actual: Y };
+
+
+//
+// fr-FR and en-US should have the same keys
+//
+type EnKeys = ExtractTranslationKeys<typeof locales["en-US"]>;
+type FrKeys = ExtractTranslationKeys<typeof locales["fr-FR"]>;
+
+// @ts-expect-error : TS6133 - assertTranslationKeysMatch is not used
+function assertTranslationKeysMatch(): AssertIsStrictEqual<EnKeys, FrKeys> {
+  return true;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noErrorTruncation": false, // Turn on to see the full error message
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": [
@@ -35,5 +36,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src", "cunningham.ts", "common.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,10 +1120,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openfun/cunningham-react@3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-3.2.2.tgz#ba87442a51666eabb292d72c71c695dafbf5856e"
-  integrity sha512-yhVizO40D0wFGUxXEIOmAu9ujPq0xfUzOey8kibVNZAIGHaVDfVgJLNMVQSpBr4HHIqUZoJvGLPxHegcmKbvow==
+"@openfun/cunningham-react@3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-3.2.3.tgz#107bddbbe3b487734e4c6fedee38461f45f8035e"
+  integrity sha512-itmlw1nxts+iUcPpXsTl7LWpDzA9OfQh8ox2P7HxR4a7kmQpN7Z3OGcrsiaj8jwsbJpdgOSouWubvQ3OZ25BAg==
   dependencies:
     "@fontsource-variable/roboto-flex" "5.2.5"
     "@fontsource/material-icons-outlined" "5.2.5"


### PR DESCRIPTION
With [my commit](https://github.com/suitenumerique/ui-kit/pull/104/commits/7f72f5e20ae5c44d461bcf91c5911e2012e7d71d) to get translation keys autocompletion we are now easily able to compare french translation keys against english ones and immediately identity missing keys.

Ensure that french translations keys are strictly equal to english ones. So if both translations are not equal, an TS error will be raised.