### PR TITLE
🔧(tree) add dndRootElement prop to TreeView

### DIFF
--- a/src/components/tree-view/TreeView.tsx
+++ b/src/components/tree-view/TreeView.tsx
@@ -23,8 +23,8 @@ export type OpenMap = {
 
 export type TreeViewProps<T> = {
   initialOpenState?: OpenMap;
+  dndRootElement?: HTMLElement | null;
   selectedNodeId?: string;
-
   rootNodeId: string;
   canDrop?: (args: {
     parentNode: NodeApi<TreeDataItem<T>> | null;
@@ -39,6 +39,7 @@ export type TreeViewProps<T> = {
 
 export const TreeView = <T,>({
   initialOpenState,
+  dndRootElement,
   selectedNodeId,
   rootNodeId,
   renderNode,
@@ -203,6 +204,7 @@ export const TreeView = <T,>({
       className="c__tree-view--container"
     >
       <Tree
+        dndRootElement={dndRootElement}
         data={treeData}
         ref={context.treeApiRef}
         openByDefault={false}


### PR DESCRIPTION
## Purpose

If `dndRootElement` in not defined, the drag and drop events listen the full document. When a drag start, an invisible overlay is created to capture the drop events. This overlay can block the dnd of other elements in the page, like the DND of Blocknote editor in our case.
By setting the `dndRootElement`, the overlay will be confined to the specified element, preventing it from blocking DND events of other elements.

See: https://github.com/suitenumerique/docs/issues/1284

The overlay comes from here: https://github.com/brimdata/react-arborist/blob/c851c6f76ad5878f3ea7b68602e9b2f970df142e/modules/react-arborist/src/components/default-drag-preview.tsx#L46-L52

