### PR TITLE
🐛(layout) fix panel transitions and resize handling

### DIFF
--- a/src/components/language/language-picker.tsx
+++ b/src/components/language/language-picker.tsx
@@ -1,6 +1,10 @@
 import { Button, ButtonProps } from "@openfun/cunningham-react";
 import { useEffect, useMemo, useState } from "react";
-import { useDropdownMenu, DropdownMenu, DropdownMenuOption } from ":/components/dropdown-menu";
+import {
+  useDropdownMenu,
+  DropdownMenu,
+  DropdownMenuOption,
+} from ":/components/dropdown-menu";
 import { Icon, IconSize } from ":/components/icon";
 
 export type LanguagePickerProps = {
@@ -20,18 +24,25 @@ export type LanguagePickerProps = {
  * - `size`: The size of the CTA.
  * - `color`: The color of the CTA.
  */
-export const LanguagePicker = ({ languages, onChange, size, color = "primary-text", fullWidth }: LanguagePickerProps) => {
-  const {isOpen, setIsOpen} = useDropdownMenu();
+export const LanguagePicker = ({
+  languages,
+  onChange,
+  size,
+  color = "primary-text",
+  fullWidth,
+}: LanguagePickerProps) => {
+  const { isOpen, setIsOpen } = useDropdownMenu();
   const getInitialLanguage = () => {
     const selectedLanguage = languages.find((lang) => lang.isChecked);
     return selectedLanguage?.value ?? languages[0].value!;
-  }
-  const [selectedLanguage, setSelectedLanguage] = useState<string>(getInitialLanguage);
+  };
+  const [selectedLanguage, setSelectedLanguage] =
+    useState<string>(getInitialLanguage);
 
   const handleLanguageChange = (value: string) => {
     setSelectedLanguage(value);
-    onChange?.(value)
-  }
+    onChange?.(value);
+  };
 
   const iconSize = useMemo((): IconSize | undefined => {
     if (!size) return undefined;
@@ -50,6 +61,7 @@ export const LanguagePicker = ({ languages, onChange, size, color = "primary-tex
    */
   useEffect(() => {
     setSelectedLanguage(getInitialLanguage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [languages]);
 
   return (
@@ -76,4 +88,4 @@ export const LanguagePicker = ({ languages, onChange, size, color = "primary-tex
       </Button>
     </DropdownMenu>
   );
-}
+};

--- a/src/components/layout/index.scss
+++ b/src/components/layout/index.scss
@@ -4,6 +4,15 @@
   display: flex;
   flex-direction: column;
   height: 100dvh;
+
+  // Disable transitions during window resize to prevent mobile panels from being visible
+  &.resizing {
+    .c__left-panel__mobile,
+    .c__right-panel__mobile,
+    .c__right-panel {
+      transition: none !important;
+    }
+  }
 }
 
 .c__main-layout__header {

--- a/src/components/layout/left-panel/index.scss
+++ b/src/components/layout/left-panel/index.scss
@@ -12,14 +12,15 @@
 .c__left-panel__mobile {
   z-index: 999;
   width: 100dvw;
-
   height: calc(100dvh - 52px);
   overflow-y: auto;
   border-right: 1px solid var(--c--theme--colors--greyscale-200);
   position: fixed;
   background-color: var(--c--theme--colors--greyscale-000);
-  transition: transform 0.15s ease-in-out;
   transform: translateX(-100dvw);
+
+  // Animation for both opening and closing
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
   &.open {
     transform: translateX(0);

--- a/src/components/layout/right-panel/index.scss
+++ b/src/components/layout/right-panel/index.scss
@@ -1,10 +1,9 @@
 .c__right-panel {
   height: calc(100dvh - 52px);
-
   width: 0;
   border-left: 1px solid var(--c--theme--colors--greyscale-200);
-  transition: width 0.15s ease-in-out;
   overflow-y: auto;
+  transition: width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
   &.open {
     width: 300px;
@@ -18,8 +17,10 @@
   overflow-y: auto;
   position: fixed;
   background-color: var(--c--theme--colors--greyscale-000);
-  transition: transform 0.15s ease-in-out;
   transform: translateX(100dvw);
+
+  // Animation for both opening and closing
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
   &.open {
     transform: translateX(0);


### PR DESCRIPTION
- Added a class to disable transitions during window resizing to prevent mobile panels from being visible.
- Updated the MainLayout component to manage resizing state and optimize panel visibility.
- Enhanced transition effects for left and right panels for smoother animations.
- Refactored the useResponsive hook to improve performance and responsiveness.

close #113 #93 