### PR TITLE
✨(tree-view) load children on keyboard navigation and simplify toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- Enable child node loading and fold/unfold via keyboard without requiring an initial mouse click.
+
 ## 0.16.1
 
 ### Patch Changes


### PR DESCRIPTION
Fix TreeViewItem keyboard toggling for child nodes: children has to load when toggling via keyboard.
Refactors arrow click to use node.toggle() instead of handleClick.

The issue in docs app is that fold/unfold via keyboard don’t work initially when multiple subdocs are present, a mouse click is required first before keyboard toggling became functional.

See: https://github.com/suitenumerique/docs/pull/1388