### PR TITLE
✨(tree-view) improve keyboard accessibility and focus behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Patch Changes
 
-- Enable child node loading and fold/unfold via keyboard without requiring an initial mouse click.
+- a11y : improves keyboard accessibility in the TreeView component
+- a11y : Enable child node loading and fold/unfold via keyboard without requiring an initial mouse click.
 
 ## 0.16.1
 

--- a/src/components/tree-view/TreeView.tsx
+++ b/src/components/tree-view/TreeView.tsx
@@ -323,6 +323,28 @@ const Row = <T,>({ children, ...props }: RowProps<T>) => {
 
   const { style } = props.attrs;
   const newStyle = { ...style };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    const target = e.target as HTMLElement | null;
+    if (target) {
+      const isInActionsToolbar = target.closest(".actions");
+      const interactiveSelector = 'button, a[href], input, textarea, select, [role="menuitem"], [role="button"]';
+      const isInteractive = target.closest(interactiveSelector);
+      if (isInActionsToolbar || isInteractive) {
+        return;
+      }
+    }
+    if (e.key === "Enter" || e.key === " ") {
+      e.currentTarget.click();
+    }
+    if (e.key === "F2") {
+      e.preventDefault();
+      // Focus the action button inside this node
+      const actionsButton = e.currentTarget.querySelector("button");
+      if (actionsButton) {
+        actionsButton.focus();
+      }
+    }
+  };
 
   if (isTitle || isSeparator) {
     return (
@@ -347,6 +369,7 @@ const Row = <T,>({ children, ...props }: RowProps<T>) => {
       ref={props.innerRef}
       onFocus={(e) => e.stopPropagation()}
       onClick={props.node.handleClick}
+      onKeyDown={handleKeyDown}
     >
       <div className="c__tree-view--row-content">{children}</div>
     </div>

--- a/src/components/tree-view/index.scss
+++ b/src/components/tree-view/index.scss
@@ -27,6 +27,15 @@
   align-items: center;
 }
 
+.c__tree-view--row {
+  outline: none;
+
+  &:focus-visible .c__tree-view--node {
+    box-shadow: 0 0 0 2px var(--c--theme--colors--primary-500);
+    border-radius: 4px;
+  }
+}
+
 .c__tree-view--node__separator {
   display: flex;
   align-items: center;

--- a/src/components/tree-view/stories/tree-view-exemple.scss
+++ b/src/components/tree-view/stories/tree-view-exemple.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.c__tree-view--row:focus-within .c__tree-view--node .actions {
+  opacity: 1;
+}
+
 .right-panel {
   display: flex;
   flex-direction: column;

--- a/src/components/tree-view/stories/tree-view-item-exemple.tsx
+++ b/src/components/tree-view/stories/tree-view-item-exemple.tsx
@@ -13,16 +13,23 @@ import {
   Input,
   Modal,
   ModalSize,
+  useCunningham,
   useModal,
 } from "@openfun/cunningham-react";
 import { useTreeContext } from "../providers/TreeContext";
+import { useArrowRoving } from ":/hooks/useArrowRoving";
+import { useRef } from "react";
 
 type TreeViewItemExempleProps = TreeViewNodeProps<TreeViewExempleData> & {};
 
 export const TreeViewItemExemple = ({ ...props }: TreeViewItemExempleProps) => {
   const { isOpen, setIsOpen } = useDropdownMenu();
+  const { t } = useCunningham();
+
   const context = useTreeContext<TreeViewExempleData>();
   const modal = useModal();
+  const actionsRef = useRef<HTMLDivElement | null>(null);
+  useArrowRoving(actionsRef.current);
 
   const options = [
     {
@@ -73,6 +80,11 @@ export const TreeViewItemExemple = ({ ...props }: TreeViewItemExempleProps) => {
     },
   ];
 
+  const handleOpenMenu: React.MouseEventHandler<HTMLElement> = (e) => {
+    e.stopPropagation();
+    setIsOpen((prev) => !prev);
+  };
+
   return (
     <>
       <TreeViewItem {...props}>
@@ -84,17 +96,27 @@ export const TreeViewItemExemple = ({ ...props }: TreeViewItemExempleProps) => {
               <span className="name">
                 {props.node.data.value.name} -- {props.node.data.value.id}
               </span>
-              <div className={`actions ${isOpen ? "show-actions" : ""}`}>
-                <div style={{ display: "flex", alignItems: "center" }}>
+              <div
+                className={`actions ${isOpen ? "show-actions" : ""}`}
+                ref={actionsRef}
+                role="toolbar"
+                aria-label={t("components.tree-view.node-actions")}
+              >
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: "8px" }}
+                >
                   <DropdownMenu
                     onOpenChange={setIsOpen}
                     isOpen={isOpen}
                     options={options}
                   >
-                    <Button size="small" onClick={() => setIsOpen(!isOpen)}>
+                    <Button size="small" onClick={(e) => handleOpenMenu(e)}>
                       Open
                     </Button>
                   </DropdownMenu>
+                  <Button size="small" onClick={(e) => handleOpenMenu(e)}>
+                    Open
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/hooks/useArrowRoving.ts
+++ b/src/hooks/useArrowRoving.ts
@@ -1,0 +1,94 @@
+import { useEffect } from "react";
+
+/**
+ * useArrowRoving
+ *
+ * Hook to manage keyboard navigation with ArrowLeft / ArrowRight inside a toolbar of actions.
+ * - ArrowLeft / ArrowRight → move focus between buttons in the same container (roving focus).
+ * - Enter → still activate the focused button normally, except right after roving
+ *   where the hook suppresses the "phantom click" (to avoid triggering actions by mistake).
+ *
+ * Usage:
+ *   const actionsRef = useRef<HTMLDivElement | null>(null);
+ *   useArrowRoving(actionsRef.current);
+ *
+ *   return (
+ *     <div ref={actionsRef}>
+ *       <button>Option 1</button>
+ *       <button>Option 2</button>
+ *     </div>
+ *   );
+ */
+
+export function useArrowRoving(container: HTMLElement | null): void {
+  useEffect(() => {
+    if (!container) return;
+
+    let blockNextActivate = false;
+
+    const getButtons = (): HTMLButtonElement[] =>
+      Array.from(container.querySelectorAll("button")).filter(
+        (btn): btn is HTMLButtonElement =>
+          !btn.disabled && btn.getAttribute("aria-disabled") !== "true"
+      );
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const isArrowKey = e.key === "ArrowLeft" || e.key === "ArrowRight";
+      const isActivationKey = e.key === " ";
+      const isHTMLElementTarget = e.target instanceof HTMLElement;
+      if (!isHTMLElementTarget) return;
+
+      if (isActivationKey) {
+        const btn = e.target.closest("button");
+        const isValidButton =
+          btn instanceof HTMLButtonElement && container.contains(btn);
+        if (isValidButton) {
+          btn.click();
+        }
+        return;
+      }
+
+      if (!isArrowKey) return;
+
+      const btn = e.target.closest("button");
+      const isValidButton =
+        btn instanceof HTMLButtonElement && container.contains(btn);
+      if (!isValidButton) return;
+
+      const buttons = getButtons();
+      const buttonIndex = buttons.indexOf(btn as HTMLButtonElement);
+      if (buttonIndex < 0) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const nextButtonIndex =
+        e.key === "ArrowRight"
+          ? (buttonIndex + 1) % buttons.length
+          : (buttonIndex - 1 + buttons.length) % buttons.length;
+
+      buttons[nextButtonIndex].focus();
+      blockNextActivate = true;
+    };
+
+    // Prevents accidental click when pressing Enter/Space right after roving
+    const onKeyUp = (e: KeyboardEvent): void => {
+      if (!blockNextActivate) return;
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      blockNextActivate = false;
+    };
+
+    // Intercept events before they bubble
+    const options: AddEventListenerOptions = { capture: true };
+    container.addEventListener("keydown", onKeyDown, options);
+    container.addEventListener("keyup", onKeyUp, options);
+
+    return () => {
+      container.removeEventListener("keydown", onKeyDown, options);
+      container.removeEventListener("keyup", onKeyUp, options);
+    };
+  }, [container]);
+}


### PR DESCRIPTION
This PR improves keyboard accessibility in the TreeView component:

issue [1391](https://github.com/suitenumerique/docs/issues/1391) [1392](https://github.com/suitenumerique/docs/issues/1392)

- Previously, onClick intercepted all interactions, preventing Enter/Space from toggling the node when navigating with the keyboard.
- Now, onKeyDown handles Enter and Space to toggle the node open/closed.
- F2 moves focus to the node’s action button.
- While focused on the button, Enter activates the selected option.
- ArrowLeft and ArrowRight moves focus on the previous or next action button

https://github.com/user-attachments/assets/402ac16a-ea6b-48c4-97a9-2fe6c0ffc4b9


This change ensures consistent and WCAG-compliant behavior for keyboard users.