### PR TITLE
✨(frontend) expose useArrowRoving hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - a11y : improves keyboard accessibility in the TreeView component
 - a11y : Enable child node loading and fold/unfold via keyboard without requiring an initial mouse click.
+- a11y : Expose useArrowRoving hook
 
 ## 0.16.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export * from "./components/form/label/label";
 export * from "./components/badge";
 export * from "./components/icon";
 export * from "./hooks/useResponsive";
+export * from "./hooks/useArrowRoving";
 export * from "./components/share";
 export * from "./components/users";
 export * from "./hooks/useCustomTranslations";


### PR DESCRIPTION
Expose useArrowRoving hook so it can be reused across the application instead of duplicating logic.