### PR TITLE
🔧(font) export Marianne font css

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "require": "./dist/index.cjs"
     },
     "./style": "./dist/style.css",
-    "./sass/fonts": "./dist/sass/fonts.scss"
+    "./sass/fonts": "./dist/sass/fonts.scss",
+    "./fonts/Marianne": "./dist/assets/fonts/Marianne/Marianne-font.css"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Purpose

In Docs for the moment we have to extract the Marianne font from the package to paste it to the public repository.
By exposing the css font, we can avoid that, and leverage the automatic bundling.


## Proposal

We update our `package.json` to include the font CSS file in the exports and ensuring that the font can be imported correctly in both CSS and JavaScript/TypeScript files.

--- 

On the app side it would be imported like that:

```css
/* global.css: */
@import url('@gouvfr-lasuite/ui-kit/fonts/Marianne');
```