### PR TITLE
🐛(component) fix styles to use the new globals breakpoints

### DIFF
--- a/src/components/hero/index.scss
+++ b/src/components/hero/index.scss
@@ -2,8 +2,8 @@
 @use "@openfun/cunningham-react/style" as *;
 @use "../../cunningham-tokens-sass" as *;
 
-$md: map.get($themes, "default", "theme", "breakpoints", "md");
-$sm: map.get($themes, "default", "theme", "breakpoints", "sm");
+$md: map.get($themes, "default", "globals", "breakpoints", "md");
+$sm: map.get($themes, "default", "globals", "breakpoints", "sm");
 
 .c__home-gutter {
   display: flex;

--- a/src/components/share/modal/share-modal.scss
+++ b/src/components/share/modal/share-modal.scss
@@ -2,7 +2,7 @@
 @use "@openfun/cunningham-react/style" as *;
 @use "../../../cunningham-tokens-sass" as *;
 
-$md: map.get($themes, "default", "theme", "breakpoints", "md");
+$md: map.get($themes, "default", "globals", "breakpoints", "md");
 
 .c__share-modal__members {
   display: flex;


### PR DESCRIPTION
Updated the Hero and Share Modal components to reference the new globals for breakpoints in their styles.