### PR TITLE
🐛(frontend) fix phantom selection issue between nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 - hide waffle icon from screen readers
+- Clicking between nodes no longer triggers phantom selection.
 
 ## 0.19.10
 
@@ -42,13 +43,13 @@
 
 ### Patch Changes
 
-- Fix the delete option visibility in access role dropdown 
+- Fix the delete option visibility in access role dropdown
 
 ## 0.19.4
 
 ### Patch Changes
 
-- Fix the delete option visibility in access role dropdown 
+- Fix the delete option visibility in access role dropdown
 
 ## 0.19.3
 
@@ -58,13 +59,13 @@
 
 ## 0.19.2
 
-### Minor Changes 
+### Minor Changes
 
--  add can_delete property and improve ShareModal Storybook docs 
+- add can_delete property and improve ShareModal Storybook docs
 
 ## 0.19.1
 
-### Minor Changes 
+### Minor Changes
 
 - Add ReleaseNoteModal component
 - Move delete access into AccessRoleDropdown.
@@ -80,9 +81,9 @@
 
 ## 0.19.0
 
-### Minor Changes 
+### Minor Changes
 
-- Add ContextMenu component 
+- Add ContextMenu component
 - Add OnBoardingModal component
 
 ## 0.18.7
@@ -100,7 +101,7 @@
 ### Minor Changes
 
 - Update `UserAvatar` and `UserMenu` components to stick to the Figma design
-- Upgrade to latest Cunningham tokens (@openfun/cunningham-* -> @gouvfr-lasuite/cunningham-*)
+- Upgrade to latest Cunningham tokens (@openfun/cunningham-_ -> @gouvfr-lasuite/cunningham-_)
 - Export White Label & ANCT themes with light/dark variants
 - Export `getUIKitThemesFromGlobals` utility function to create a custom from UI Kit globals and overrides
 

--- a/src/components/tree-view/TreeView.tsx
+++ b/src/components/tree-view/TreeView.tsx
@@ -396,15 +396,7 @@ const Row = <T,>({ children, customRowProps, ...props }: RowProps<T>) => {
       key={props.node.id}
       ref={props.innerRef}
       onFocus={(e) => e.stopPropagation()}
-      onClick={(e) => {
-        onClick?.(e);
-
-        // Prevent automatic opening on click
-        e.preventDefault();
-        e.stopPropagation();
-        // Only select, don't open
-        props.node.select();
-      }}
+      onClick={props.node.handleClick}
       onKeyDown={handleKeyDown}
       {...restCustomRowProps}
     >

--- a/src/components/tree-view/index.scss
+++ b/src/components/tree-view/index.scss
@@ -30,6 +30,7 @@
 
 .c__tree-view--row {
   outline: none;
+  pointer-events: none;
 
   &:focus-visible .c__tree-view--node {
     box-shadow: 0 0 0 2px
@@ -90,6 +91,7 @@
   border: 1.5px solid rgba(0, 0, 0, 0);
   cursor: pointer;
   padding: var(--c--globals--spacings--4xs) 0;
+  pointer-events: auto;
   gap: var(--c--globals--spacings--3xs);
 
   &.simpleNode {


### PR DESCRIPTION
### Purpose

This PR fixes a phantom selection issue that occurred when switching between nodes in the document editor. It ensures that no invisible selection persists when moving between elements.

To test it just ajust rowHeight in TreeView to 50 and clic between nodes

issue : [1472](https://github.com/suitenumerique/docs/issues/1472)

Before : 

https://github.com/user-attachments/assets/585830f7-8cfc-44d1-8447-257ebf64e3b6

After: 

https://github.com/user-attachments/assets/66ce9d86-3528-42e5-803e-313a2aeaaa83

### Proposal

- [x] Fix node selection logic to prevent phantom selections
- [x] Ensure selection state is properly cleared when switching nodes
- [x] Manually tested across multiple node transitions to validate behavior

