### PR TITLE
💄(styles) fix some style issues after the uikit v2 refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- Several patch fixes after the uikit v2 refactoring
+
 ## 0.17.2
 
 ### Patch Changes

--- a/cunningham.ts
+++ b/cunningham.ts
@@ -355,14 +355,14 @@ const designTokens = {
           tablet: "1024px",
         },
       },
-      
+
       components: {
         modal: {
           "width-small": "342px",
         },
         tooltip: {
           padding: "4px 8px",
-          "background-color": "ref(globals.colors.greyscale-1000)",
+          "background-color": "ref(contextuals.background.semantic.neutral.tertiary)",
         },
         button: {
           "medium-height": "40px",
@@ -378,7 +378,7 @@ const designTokens = {
           "body--background-color-hover": "ref(contextuals.background.semantic.neutral.tertiary)",
         },
         "forms-checkbox": {
-          "font-size": "ref(globals.font.sizes.sm)",          
+          "font-size": "ref(globals.font.sizes.sm)",
         },
         "badge": {
           "font-size": "ref(globals.font.sizes.xs)",
@@ -412,7 +412,7 @@ const designTokens = {
         },
       },
     },
-  }  
+  }
 };
 
 const config = { ...designTokens  };

--- a/src/components/dropdown-menu/index.scss
+++ b/src/components/dropdown-menu/index.scss
@@ -53,17 +53,11 @@
     flex: 1;
   }
 
+  &[data-focused],
   &:hover {
     background: var(
       --c--contextuals--background--semantic--contextual--primary
     );
-  }
-
-  &[data-focused] {
-    background: var(
-      --c--contextuals--background--semantic--contextual--primary
-    );
-    color: black;
   }
 
   &[data-disabled] {

--- a/src/components/hero/index.scss
+++ b/src/components/hero/index.scss
@@ -80,7 +80,7 @@ $sm: map.get($themes, "default", "globals", "breakpoints", "sm");
     > img {
       width: auto;
       max-width: 100%;
-      height: fit-content;
+      object-fit: contain;
       overflow: auto;
       max-height: 100%;
       width: 50%;

--- a/src/components/users/menu/index.tsx
+++ b/src/components/users/menu/index.tsx
@@ -95,7 +95,7 @@ export const UserMenu = ({
                   typeof settingsCTA === "function" ? settingsCTA : undefined
                 }
                 href={typeof settingsCTA === "string" ? settingsCTA : undefined}
-                variant="primary"
+                variant="secondary"
                 size="small"
                 icon={<Icon name="account_box" />}
               >


### PR DESCRIPTION
By migrating a projet to the uikit v2, I found several little issues :
- Dropdown menu item hover color issue on dark mode
- Tooltip wrong background-color
- Hero image ratio not preserved