### PR TITLE
🐛(Icon) fix icon size css selector specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- Fix icon size CSS selector specificity issue
+
 ## 0.18.5
 
 ### Minor Changes
@@ -10,19 +14,19 @@
 
 ## 0.18.4
 
-### Patch Changes 
+### Patch Changes
 
 - fix LaGaufreV2 component rerender and add headerLogo for mobile
 
 ## 0.18.3
 
-### Patch Changes 
+### Patch Changes
 
 - fixes the responsiveness of the User Menu component
 
 ## 0.18.2
 
-### Patch Changes 
+### Patch Changes
 
 - fix missing export LaGaufreV2 component
 
@@ -36,7 +40,7 @@
 
 ### Major changes
 
-- Add pagination to the tree components 
+- Add pagination to the tree components
 
 ### Patch Changes
 

--- a/src/components/icon/Icon.stories.tsx
+++ b/src/components/icon/Icon.stories.tsx
@@ -48,13 +48,23 @@ export const Default: Story = {
 // Different sizes
 export const Sizes: Story = {
   render: () => (
-    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
-      <Icon name="home" size={IconSize.X_SMALL} />
-      <Icon name="home" size={IconSize.SMALL} />
-      <Icon name="home" size={IconSize.MEDIUM} />
-      <Icon name="home" size={IconSize.LARGE} />
-      <Icon name="home" size={IconSize.X_LARGE} />
-      <Icon name="home" size={84} />
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+        <Icon name="home" size={IconSize.X_SMALL} />
+        <Icon name="home" size={IconSize.SMALL} />
+        <Icon name="home" size={IconSize.MEDIUM} />
+        <Icon name="home" size={IconSize.LARGE} />
+        <Icon name="home" size={IconSize.X_LARGE} />
+        <Icon name="home" size={84} />
+      </div>
+      <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+        <Icon name="home" size={IconSize.X_SMALL} type={IconType.OUTLINED} />
+        <Icon name="home" size={IconSize.SMALL} type={IconType.OUTLINED} />
+        <Icon name="home" size={IconSize.MEDIUM} type={IconType.OUTLINED} />
+        <Icon name="home" size={IconSize.LARGE} type={IconType.OUTLINED} />
+        <Icon name="home" size={IconSize.X_LARGE} type={IconType.OUTLINED} />
+        <Icon name="home" size={84} type={IconType.OUTLINED} />
+      </div>
     </div>
   ),
 };

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -42,11 +42,10 @@ export const Icon: React.FC<IconProps> = ({
   ...props
 }) => {
   const iconClasses = clsx(
-    ``,
+    "material-icons",
     {
       [`icon--${size}`]: size !== undefined,
-      [`material-icons-${type}`]: type !== IconType.OUTLINED,
-      "material-icons": type === IconType.OUTLINED,
+      [`icon--${type}`]: type !== IconType.OUTLINED,
     },
     className
   );

--- a/src/components/icon/index.scss
+++ b/src/components/icon/index.scss
@@ -1,46 +1,24 @@
-.material-icons-filled {
+.material-icons.icon--filled {
   font-family: "Material Icons", sans-serif;
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  display: inline-block;
-  line-height: 1;
-  text-transform: none;
-  letter-spacing: normal;
-  word-wrap: normal;
-  white-space: nowrap;
-  direction: ltr;
-
-  /* Support for all WebKit browsers. */
-  -webkit-font-smoothing: antialiased;
-
-  /* Support for Safari and Chrome. */
-  text-rendering: optimizelegibility;
-
-  /* Support for Firefox. */
-  -moz-osx-font-smoothing: grayscale;
-
-  /* Support for IE. */
-  font-feature-settings: "liga";
 }
 
 // Icon sizes
-.icon--xsmall {
+.material-icons.icon--xsmall {
   font-size: 11px;
 }
 
-.icon--small {
+.material-icons.icon--small {
   font-size: 16px;
 }
 
-.icon--medium {
+.material-icons.icon--medium {
   font-size: 24px;
 }
 
-.icon--large {
+.material-icons.icon--large {
   font-size: 32px;
 }
 
-.icon--xlarge {
+.material-icons.icon--xlarge {
   font-size: 48px;
 }


### PR DESCRIPTION
The icon size modifiers had a CSS specificity too low when using outlined icon. We fix that to be able to apply size on this icon type.