### PR TITLE
✨(tree) add custom row props to TreeView components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Minor Changes
+
+- Add props to customize row in TreeView component
+
 ## 0.18.4
 
 ### Patch Changes 

--- a/src/components/tree-view/TreeViewItem.tsx
+++ b/src/components/tree-view/TreeViewItem.tsx
@@ -1,6 +1,6 @@
 import { NodeRendererProps } from "react-arborist";
 import { TreeDataItem, TreeViewNodeTypeEnum } from "./types";
-import {
+import React, {
   PropsWithChildren,
   useCallback,
   useEffect,
@@ -14,13 +14,17 @@ import { useTreeContext } from "./providers/TreeContext";
 import { useCunningham } from "@openfun/cunningham-react";
 
 export type TreeViewNodeProps<T> = NodeRendererProps<TreeDataItem<T>> & {
+  itemProps?: React.HTMLAttributes<HTMLDivElement>;
   onClick?: () => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
   forceLoading?: boolean;
 };
 
 export const TreeViewItem = <T,>({
   children,
+  itemProps,
   onClick,
+  onKeyDown,
   node,
   dragHandle,
   style,
@@ -154,13 +158,15 @@ export const TreeViewItem = <T,>({
           onClick?.();
         }}
         onKeyDown={(e) => {
+          onKeyDown?.(e);
+          
           // We stop all propagation if it's not a tree view item
           const target = e.target as HTMLElement;
           const isItem = target.closest(".c__tree-view--node");
           if (!isItem) {
             e.stopPropagation();
           }
-        }}
+        }} 
         ref={dragHandle}
         style={style}
         className={clsx("c__tree-view--node", {
@@ -170,6 +176,7 @@ export const TreeViewItem = <T,>({
           ["canDrop"]: node.data.value.canDrop ?? true,
           ["externalDrop"]: externalOver,
         })}
+        {...itemProps}
       >
         {isLeaf && <div className="c__tree-view--node__leaf" />}
         {!isLeaf && (

--- a/src/components/tree-view/stories/tree-view-example.tsx
+++ b/src/components/tree-view/stories/tree-view-example.tsx
@@ -63,6 +63,7 @@ export const TreeViewExample = ({
   withRightPanel = false,
 }: TreeViewExampleProps) => {
   const treeContext = useTreeContext<TreeViewExampleData>();
+  const [selectedNodeText, setSelectedNodeText] = useState<string>("Node 1");
 
   const [draggingData, setDraggingData] = useState<TreeViewExampleData | null>(
     null
@@ -133,6 +134,20 @@ export const TreeViewExample = ({
                 rootNodeId="ROOT_NODE_ID"
                 selectedNodeId={"1"}
                 renderNode={TreeViewItemExample}
+                rowProps={{
+                  onKeyDown: (e) => {
+                    if (e.key === "Enter") {
+                      const selectedText = e.currentTarget
+                        .getElementsByClassName("name")?.[0].innerHTML
+                      setSelectedNodeText(selectedText);
+                    }
+                  },
+                  onClick: (e) => {
+                    const selectedText = (e.currentTarget as HTMLElement)
+                      .getElementsByClassName("name")?.[0].innerHTML
+                    setSelectedNodeText(selectedText);
+                  },
+                }}
               />
             </div>
           }
@@ -160,6 +175,7 @@ export const TreeViewExample = ({
               </div>
             </div>
           )}
+          <div>Display node {selectedNodeText}</div>
           <button onClick={() => treeContext?.treeData.resetTree(data)}>
             Reset
           </button>


### PR DESCRIPTION
## Purpose

We need to be able to pass custom props to the rows of the `TreeView` component for better
flexibility, particulary about accessibility. 
This PR introduces a new prop `rowProps` to the `TreeView` component that allows users to specify additional HTML attributes for each row.
We added as well `itemProps` to `TreeViewItem` for the same purpose.


https://github.com/user-attachments/assets/929de7ae-6606-4348-9f7a-c7021e623359

