### PR TITLE
💄(users) stick user avatar and menu to figma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Minor Changes
+
+- Update `UserAvatar` and `UserMenu` components to stick to the Figma design
+
 ### Patch Changes
 
 - Fix icon size CSS selector specificity issue

--- a/src/components/users/avatar/index.scss
+++ b/src/components/users/avatar/index.scss
@@ -3,8 +3,11 @@
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  color: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  // Use raw token value as fallback for browsers that don't support color-mix
+  color: var(--c--contextuals--background--surface--tertiary);
+  color: color-mix(in srgb, var(--c--contextuals--background--surface--tertiary) 95%, transparent);
+  border: 1px solid var(--c--contextuals--background--surface--tertiary);
+  border: 1px solid color-mix(in srgb, var(--c--contextuals--background--surface--tertiary) 80%, transparent);
 
   &__initials {
     display: flex;
@@ -12,9 +15,8 @@
     justify-content: center;
     text-align: center;
     font-style: normal;
-    font-weight: 600;
-    font-family: Arial, Helvetica, sans-serif;
-
+    font-weight: 700;
+    font-family: var(--c--globals--font--families--base);
     text-transform: uppercase;
   }
 
@@ -22,79 +24,72 @@
     width: 16px;
     height: 16px;
     font-size: 7px;
+    letter-spacing: -0.25px;
   }
 
   &.small {
     width: 24px;
     height: 24px;
     font-size: 10px;
+    letter-spacing: -0.35px;
   }
 
   &.medium {
     width: 32px;
     height: 32px;
-    font-size: 12px;
+    font-size: 11px;
+    letter-spacing: -0.38px;
+
   }
 
   &.large {
     width: 64px;
     height: 64px;
-    font-size: 26px;
+    font-size: 27px;
+    letter-spacing: -0.54px;
   }
 
   &.brand {
-    background-color: var(--c--globals--colors--brand-500);
+    background-color: var(--c--contextuals--background--palette--brand--primary);
   }
 
   &.gray {
-    background-color: var(--c--globals--colors--gray-500);
-  }
-
-  &.info {
-    background-color: var(--c--globals--colors--info-500);
-  }
-
-  &.success {
-    background-color: var(--c--globals--colors--success-500);
-  }
-
-  &.warning {
-    background-color: var(--c--globals--colors--warning-500);
-  }
-
-  &.error {
-    background-color: var(--c--globals--colors--error-500);
+    background-color: var(--c--contextuals--background--palette--gray--primary);
   }
 
   &.purple {
-    background-color: var(--c--globals--colors--purple-500);
+    background-color: var(--c--contextuals--background--palette--purple--primary);
   }
 
-  &.blue {
-    background-color: var(--c--globals--colors--blue-1-500);
+  &.blue-1 {
+    background-color: var(--c--contextuals--background--palette--blue-1--primary);
+  }
+
+  &.blue-2 {
+    background-color: var(--c--contextuals--background--palette--blue-2--primary);
   }
 
   &.green {
-    background-color: var(--c--globals--colors--green-500);
+    background-color: var(--c--contextuals--background--palette--green--primary);
   }
 
   &.yellow {
-    background-color: var(--c--globals--colors--yellow-500);
+    background-color: var(--c--contextuals--background--palette--yellow--primary);
   }
 
   &.orange {
-    background-color: var(--c--globals--colors--orange-500);
+    background-color: var(--c--contextuals--background--palette--orange--primary);
   }
 
   &.red {
-    background-color: var(--c--globals--colors--red-500);
+    background-color: var(--c--contextuals--background--palette--red--primary);
   }
 
   &.brown {
-    background-color: var(--c--globals--colors--brown-500);
+    background-color: var(--c--contextuals--background--palette--brown--primary);
   }
 
   &.pink {
-    background-color: var(--c--globals--colors--pink-500);
+    background-color: var(--c--contextuals--background--palette--pink--primary);
   }
 }

--- a/src/components/users/avatar/utils.ts
+++ b/src/components/users/avatar/utils.ts
@@ -1,18 +1,15 @@
 export const AVATAR_COLORS = [
-    "brand",
     "gray",
-    "info",
-    "success",
-    "warning",
-    "error",
+    "brand",
     "red",
     "orange",
     "brown",
-    "yellow",
     "green",
-    "purple",
+    "blue-1",
+    "blue-2",
     "pink",
-    "blue",
+    "yellow",
+    "purple",
   ];
 
 

--- a/src/components/users/menu/_index.scss
+++ b/src/components/users/menu/_index.scss
@@ -40,7 +40,7 @@
 }
 
 .user-menu__content__body {
-  padding: var(--c--globals--spacings--xs) 0;
+  padding-bottom: var(--c--globals--spacings--xs);
   display: flex;
   flex-direction: column;
   gap: var(--c--globals--spacings--xs);
@@ -55,8 +55,14 @@
   &__user-info {
     display: flex;
     align-items: center;
-    padding: var(--c--globals--spacings--xs) var(--c--globals--spacings--base);
+    padding-inline: var(--c--globals--spacings--base);
+    padding-block: var(--c--globals--spacings--md) var(--c--globals--spacings--base);
     gap: var(--c--globals--spacings--base);
+    background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--gradient-color) 8%, transparent) 0%,
+    color-mix(in srgb, var(--c--contextuals--background--surface--primary) 8%, transparent) 100%,
+    );
   }
 }
 
@@ -78,6 +84,7 @@
   color: var(--c--contextuals--content--semantic--neutral--primary);
   font-size: var(--c--globals--font--sizes--md);
   font-weight: 700;
+  line-height: 1.375;
   margin: 0;
 
   & > strong {
@@ -107,8 +114,6 @@
   gap: var(--c--globals--spacings--base);
   border-top: 1px solid var(--c--contextuals--border--surface--primary);
 
-  // Center content when there's only one item
-  &:has(.user-menu__actions__left:only-child),
   &:has(.user-menu__actions__right:only-child) {
     justify-content: flex-end;
   }

--- a/src/components/users/menu/index.stories.tsx
+++ b/src/components/users/menu/index.stories.tsx
@@ -72,6 +72,15 @@ export const WithOnlyFooterAction: Story = {
     ),
   },
 };
+export const WithOnlyTermOfService: Story = {
+  args: {
+    user: {
+      full_name: "J Doe",
+      email: "john.doe@example.com",
+    },
+    termOfServiceUrl,
+  },
+};
 
 export const Minimal: Story = {
   args: {

--- a/src/components/users/menu/index.tsx
+++ b/src/components/users/menu/index.tsx
@@ -11,6 +11,7 @@ import { UserAvatar } from ":/components/users/avatar/UserAvatar";
 import { Icon } from ":/components/icon";
 import { HorizontalSeparator } from ":/components/separator";
 import { useResponsive } from ":/hooks/useResponsive";
+import { getUserColor } from "../avatar/utils";
 
 type UserMenuContentProps = {
   user: UserMenuProps["user"];
@@ -33,14 +34,16 @@ const UserMenuContent = ({
   const showActions = !!footerAction || !!termOfServiceUrl;
 
   const { t } = useCunningham();
+  const userFullName = user ? user.full_name ?? user.email : undefined;
+  const userColor = userFullName ? getUserColor(userFullName) : undefined;
 
   if (!user) return null;
 
   return (
     <>
       <div className="user-menu__content__body">
-        <div className="user-menu__content__body__user-info">
-          <UserAvatar fullName={user.full_name ?? user.email!} />
+        <div className="user-menu__content__body__user-info" style={{ '--gradient-color': `var(--c--contextuals--background--palette--${userColor}--primary)` } as React.CSSProperties}>
+          <UserAvatar fullName={userFullName!} />
           <div className="user-menu__content__identity__name">
             {user.full_name ? (
               <>


### PR DESCRIPTION
Update UserAvatar and UserMenu component to stick to the figma file. It helps to address some color contrast issues about UserAvatar.

Furthermore, only apply `flex-end` to the action column right in the UserMenu.

| Before | After |
|--------|-------|
|<img height="50" alt="Capture d’écran 2025-12-10 à 15 43 26" src="https://github.com/user-attachments/assets/745ad9c3-7d21-4807-82c4-2e7ac35db966" />|<img height="50" alt="Capture d’écran 2025-12-10 à 15 42 15" src="https://github.com/user-attachments/assets/41776b62-fedd-4133-8d9f-08f5c2f5aaa3" />|
|<img width="330" alt="Capture d’écran 2025-12-10 à 15 43 42" src="https://github.com/user-attachments/assets/defe0d7d-15f6-4206-830d-f6795adb6b2b" />|<img width="330" alt="Capture d’écran 2025-12-10 à 15 50 00" src="https://github.com/user-attachments/assets/0bf02883-eb19-4203-a358-3391a708aaf8" />|