### PR TITLE
💄(quick-search) fix css syntax issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- Fix CSS syntax issue in QuickSearch component
+
 ## 0.18.6
 
 ### Minor Changes

--- a/src/components/quick-search/quick-search-global-style.scss
+++ b/src/components/quick-search/quick-search-global-style.scss
@@ -50,9 +50,7 @@
     }
 
     &[data-disabled="true"] {
-      background: var(
-        var(--c--contextuals--background--semantic--disabled--primary)
-      );
+      background: var(--c--contextuals--background--semantic--disabled--primary);
       cursor: not-allowed;
     }
 


### PR DESCRIPTION
`var` statement was duplicated and produce compilation error in next application using turbopack... but not with webpack bundler...