### PR TITLE
🐛(LaGaufreV2) fix update type apiUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- Fix update type apiUrl in LaGaufreV2 component
+
 ## 0.19.0
 
 ### Minor Changes 

--- a/src/components/la-gaufre/LaGaufreV2.tsx
+++ b/src/components/la-gaufre/LaGaufreV2.tsx
@@ -28,10 +28,18 @@ type ServicesResponse = {
   error?: unknown;
 };
 
-export type LaGaufreV2Props = {
-  widgetPath: string;
+type LaGaufreV2API = {
   apiUrl: string;
-  data?: ServicesResponse;
+  data?: never;
+};
+
+type LaGaufreV2Data = {
+  apiUrl?: never;
+  data: ServicesResponse;
+};
+
+export type LaGaufreV2Props = {
+  widgetPath?: string;
   fontFamily?: string;
   background?: string;
   headerLogo?: string;
@@ -44,7 +52,8 @@ export type LaGaufreV2Props = {
   showMoreLimit?: number;
   viewMoreLabel?: string;
   viewLessLabel?: string;
-};
+} & (LaGaufreV2API | LaGaufreV2Data);
+
 export const LaGaufreV2 = memo(
   ({ apiUrl, data, ...props }: LaGaufreV2Props) => {
     const { t } = useCunningham();
@@ -53,9 +62,9 @@ export const LaGaufreV2 = memo(
 
     const widgetPath = useMemo(
       () =>
-        props.widgetPath ||
+        props?.widgetPath ||
         "https://static.suite.anct.gouv.fr/widgets/lagaufre.js",
-      [props.widgetPath]
+      [props?.widgetPath]
     );
 
     const defaultApiUrl = data?.services ? undefined : apiUrl;


### PR DESCRIPTION
## Purpose

There is 2 ways to add data to LaGaufreV2 component, either using apiUrl to fetch data from an API or passing data directly from the data prop.
When using data prop, the component was giving a type error because apiUrl was required.
We fixed this by updating the LaGaufreV2Props type to make apiUrl optional when data is provided and vice versa.