### PR TITLE
🚨(frontend) remove throw error in useTreeContext

### DIFF
--- a/src/components/tree-view/providers/TreeContext.tsx
+++ b/src/components/tree-view/providers/TreeContext.tsx
@@ -63,7 +63,7 @@ export const TreeProvider = <T,>({
 export const useTreeContext = <T,>() => {
   const Context = useContext(TreeContext);
   if (!Context) {
-    throw new Error("TreeContext not found");
+    return null
   }
   return Context as TreeContextType<T> | null;
 };


### PR DESCRIPTION
I am bothered by the exception thrown useTreeContext to refactor Docs search page and search modal.