### PR TITLE
🐛(context-menu) ignore right-click events from portals

### DIFF
--- a/src/components/context-menu/ContextMenu.tsx
+++ b/src/components/context-menu/ContextMenu.tsx
@@ -41,6 +41,11 @@ export const ContextMenu = <T,>({
       return;
     }
 
+    // Ignore events from portals (e.g. modals) whose DOM is outside this wrapper
+    if (!event.currentTarget.contains(event.target as Node)) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/components/context-menu/context-menu.stories.tsx
+++ b/src/components/context-menu/context-menu.stories.tsx
@@ -1,3 +1,9 @@
+import {
+  Button,
+  Modal,
+  ModalSize,
+  useModal,
+} from "@gouvfr-lasuite/cunningham-react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { ContextMenu } from "./ContextMenu";
@@ -520,4 +526,54 @@ export const FocusHighlighting: Story = {
       ))}
     </div>
   ),
+};
+
+const WithModalContent = () => {
+  const modal = useModal();
+
+  return (
+    <ContextMenu options={basicItems}>
+      <div
+        style={{
+          padding: "40px",
+          border: "2px dashed #ccc",
+          borderRadius: "8px",
+          textAlign: "center",
+          backgroundColor: "#f9f9f9",
+        }}
+      >
+        <p style={{ marginBottom: "16px" }}>
+          Right-click here to open the context menu
+        </p>
+        <Button onClick={() => modal.open()}>Open Modal</Button>
+        <Modal
+          {...modal}
+          size={ModalSize.MEDIUM}
+          title="Modal"
+          rightActions={
+            <Button onClick={() => modal.close()}>Close</Button>
+          }
+        >
+          <p>Right-click inside this modal — the context menu should not
+            appear.</p>
+        </Modal>
+      </div>
+    </ContextMenu>
+  );
+};
+
+/**
+ * Portal isolation test.
+ *
+ * The ContextMenu wraps an area that contains a button to open a modal.
+ * When the modal is open, right-clicking inside it should **not** trigger
+ * the context menu, because the modal DOM lives in a portal outside the
+ * ContextMenu wrapper.
+ */
+export const WithModal: Story = {
+  args: {
+    options: [],
+    children: null,
+  },
+  render: () => <WithModalContent />,
 };


### PR DESCRIPTION
## Summary

- **Fix**: `ContextMenu` now checks `e.currentTarget.contains(e.target)` before opening, preventing portal-based elements (modals, dialogs) from triggering the context menu when their DOM lives outside the wrapper div
- **Story**: Added a `WithModal` story to demonstrate and verify the fix (ContextMenu + modal — right-click inside the modal no longer opens the context menu)

## Test plan

- [ ] Open the `WithModal` story in Storybook
- [ ] Right-click in the dashed zone → context menu appears ✅
- [ ] Click "Open Modal" → right-click inside the modal → context menu does **not** appear ✅
- [ ] Close the modal → right-click in the dashed zone → context menu still works ✅

