### PR TITLE
♿️(frontend) hide waffle icon from screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Patch Changes
+
+- hide waffle icon from screen readers
+
 ## 0.19.10
 
 ### Patch Changes

--- a/src/components/la-gaufre/LaGaufreV2.tsx
+++ b/src/components/la-gaufre/LaGaufreV2.tsx
@@ -150,6 +150,7 @@ export const LaGaufreV2 = memo(
                 height="18"
                 fill="none"
                 viewBox="0 0 18 18"
+                aria-hidden="true"
               >
                 <defs>
                   <path


### PR DESCRIPTION
## Purpose

Improve accessibility of the La Gaufre (waffle) button by hiding its decorative SVG icon from screen readers.

issue : [1973](https://github.com/suitenumerique/docs/issues/1973)

## Proposal

- [x] Add `aria-hidden="true"` to the waffle button SVG in LaGaufreV2
