### PR TITLE
📝 Fix documentation typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,7 +447,7 @@
 
 ### Major Changes
 
-- Add basic components: button, datagrid, dropdown-menu, modal, layouts, provider, quick-search, tabs, tree-veiw
+- Add basic components: button, datagrid, dropdown-menu, modal, layouts, provider, quick-search, tabs, tree-view
 - Add storybook
 - Add custom cunningham.ts file
 - Still a WIP version

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Design tokens are defined in `cunningham.ts` and can be overridden:
     colors: { brand-*, gray-*, info-*, success-*, warning-*, error-* },
     breakpoints: { xxs, xs, mobile, tablet },
   },
-  contextutals: {
+  contextuals: {
     background: {
         semantic: {
             brand: {


### PR DESCRIPTION
## Summary
- Fix 2 typos in documentation

## Details
- CHANGELOG.md: tree-veiw → tree-view
- README.md: contextutals → contextuals

## Test plan
- [ ] Verify changes are correct