### PR TITLE
🐛(tree-view) fix silent drop failure on expanded nodes with non-node …

### DIFF
--- a/src/components/tree-view/TreeView.tsx
+++ b/src/components/tree-view/TreeView.tsx
@@ -158,6 +158,32 @@ export const TreeView = <T,>({
       targetModeId = nextSibling.value.id;
     }
 
+    // Fallback for gaps between non-node rows (e.g. separator/view-more) to avoid silent no-op drops.
+    if (!mode) {
+      for (let i = siblingIndex; i >= 0; i--) {
+        if (children[i] && isNode(children[i].value)) {
+          targetModeId = children[i].value.id;
+          mode = TreeViewMoveModeEnum.RIGHT;
+          break;
+        }
+      }
+    }
+
+    if (!mode) {
+      for (let i = nextSiblingIndex; i < children.length; i++) {
+        if (children[i] && isNode(children[i].value)) {
+          targetModeId = children[i].value.id;
+          mode = TreeViewMoveModeEnum.LEFT;
+          break;
+        }
+      }
+    }
+
+    if (!mode) {
+      targetModeId = defaultTargetNodeId;
+      mode = TreeViewMoveModeEnum.LAST_CHILD;
+    }
+
     if (mode && targetModeId) {
       return {
         targetModeId: targetModeId,

--- a/src/components/tree-view/TreeView.tsx
+++ b/src/components/tree-view/TreeView.tsx
@@ -83,6 +83,20 @@ export const TreeView = <T,>({
     return () => observer?.disconnect();
   }, []);
 
+  /**
+   * Figures out where to drop a node by checking its two direct neighbors
+   * (the rows just before and just after the drop position). If one of them
+   * is a real node we anchor the move to it (RIGHT or LEFT).
+   *
+   * Problem: the children list can also contain non-node rows like separators,
+   * titles or view-more. If the cursor lands right between two of them (a
+   * separator followed by a title for example), neither neighbor is a real
+   * node, we can't pick a mode, and the drop is dropped silently. The node
+   * snaps back and the user gets no feedback.
+   *
+   * The fallback below looks further around the drop position to always find
+   * a real node to anchor on, so this never fails silently again.
+   */
   const getMovePosition = (args: {
     dragIds: string[];
     dragNodes: NodeApi<TreeDataItem<T>>[];
@@ -158,7 +172,9 @@ export const TreeView = <T,>({
       targetModeId = nextSibling.value.id;
     }
 
-    // Fallback for gaps between non-node rows (e.g. separator/view-more) to avoid silent no-op drops.
+    // Both neighbors are special rows, so look further away for a real node
+    // to anchor on. Backward first, then forward. If nothing, fall back to
+    // dropping as the last child of the parent.
     if (!mode) {
       for (let i = siblingIndex; i >= 0; i--) {
         if (children[i] && isNode(children[i].value)) {


### PR DESCRIPTION
## Purpose

Fix an intermittent bug where dragging a node into a parent with children can fail silently. In that case, the node goes back to its original place without any feedback.

## Proposal

- [x] Add a fallback in `getMovePosition` when the drop happens between two special rows (`separator`, `view-more`, `title`) and no move mode can be resolved.
- [x] Look around the drop index for the nearest actual node to use as an anchor, and default to `LAST_CHILD` when none is found.

### Why it's intermittent

This only happens in some drop positions. Most of the time, the drop index is next to a normal node, so the move works as expected. But in some cases, it lands between two non-node rows.