### PR TITLE
🐛(filter) prevent label wrapping in constrained containers

### DIFF
--- a/src/components/filter/Filter.stories.tsx
+++ b/src/components/filter/Filter.stories.tsx
@@ -87,6 +87,70 @@ export const UncontrolledWithDefault: Story = {
   },
 };
 
+const OPTIONS_LONG: FilterOption[] = [
+  {
+    label: "Tous les documents disponibles",
+    value: "all",
+  },
+  {
+    label: "Fichiers partagés avec mon équipe",
+    value: "file",
+  },
+  {
+    label: "Dossiers récemment modifiés par un collaborateur",
+    value: "folder",
+  },
+];
+
+export const LongLabels: Story = {
+  args: {
+    label: "Type de contenu à afficher dans la liste",
+    options: OPTIONS_LONG,
+  },
+};
+
+export const MultipleInConstrainedContainer: Story = {
+  render: () => (
+    <div
+      style={{
+        maxWidth: "600px",
+        border: "1px solid #ccc",
+        padding: "1em",
+        display: "flex",
+        gap: "1em",
+        alignItems: "center",
+        overflowX: "auto",
+      }}
+    >
+      <Filter
+        label="Type de contenu à afficher"
+        defaultSelectedKey="folder"
+        options={[
+          { label: "Dossier partagé avec l'équipe", value: "folder" },
+          { label: "Fichier récemment modifié", value: "file" },
+        ]}
+      />
+      <Filter
+        label="Espace de travail collaboratif"
+        defaultSelectedKey="public"
+        options={[
+          { label: "Espace public accessible à tous", value: "public" },
+          { label: "Espace privé réservé aux membres", value: "private" },
+        ]}
+      />
+      <Filter
+        label="Emplacement du document dans l'arborescence"
+        defaultSelectedKey="trash"
+        options={[
+          { label: "Corbeille des éléments supprimés", value: "trash" },
+          { label: "Favoris marqués par l'utilisateur", value: "favorites" },
+        ]}
+      />
+      <Button size="small">Réinitialiser</Button>
+    </div>
+  ),
+};
+
 export const Controlled: Story = {
   args: {
     label: "Type",

--- a/src/components/filter/index.scss
+++ b/src/components/filter/index.scss
@@ -1,4 +1,6 @@
 .c__filter {
+  flex-shrink: 0;
+
   &__button {
     background-color: var(
       --c--contextuals--background--semantic--neutral--tertiary
@@ -15,6 +17,7 @@
     gap: 6px;
     padding: 0 6px 0 8px;
     color: var(--c--contextuals--content--semantic--neutral--tertiary);
+    white-space: nowrap;
 
     &__icon {
       font-size: 1.25rem;
@@ -64,6 +67,7 @@
   &__label {
     display: flex;
     align-items: center;
+    white-space: nowrap;
   }
 
   &__popover {


### PR DESCRIPTION
Filter buttons were shrinking and their labels wrapped onto multiple lines when several filters sat side by side in a too-narrow container. Add flex-shrink: 0 on the root and white-space: nowrap on the button and label so each filter stays on a single line, leaving the parent to handle horizontal scrolling when needed.
