### PR TITLE
Fix/a11y share modal sr focus announcements

### DIFF
--- a/src/components/quick-search/QuickSearchInput.tsx
+++ b/src/components/quick-search/QuickSearchInput.tsx
@@ -34,7 +34,7 @@ export const QuickSearchInput = ({
   return (
     <>
       <div className="quick-search-input-container">
-        {!loading && <span className="material-icons">search</span>}
+        {!loading && <span className="material-icons" aria-hidden="true">search</span>}
         {loading && (
           <div>
             <Spinner size="md" />

--- a/src/components/share/access/AccessRoleDropdown.tsx
+++ b/src/components/share/access/AccessRoleDropdown.tsx
@@ -17,6 +17,7 @@ type AccessRoleDropdownProps = {
   roleTopMessage?: DropdownMenuProps["topMessage"];
   onDelete?: () => void;
   canDelete?: boolean;
+  "aria-label"?: string;
 };
 
 export const AccessRoleDropdown = ({
@@ -29,6 +30,7 @@ export const AccessRoleDropdown = ({
   roleTopMessage,
   onDelete,
   canDelete = true,
+  "aria-label": ariaLabel,
 }: AccessRoleDropdownProps) => {
   const { t } = useCunningham();
 
@@ -83,7 +85,7 @@ export const AccessRoleDropdown = ({
         color="brand"
         variant="tertiary"
         icon={
-          <span className="material-icons">
+          <span className="material-icons" aria-hidden="true">
             {isOpen ? "arrow_drop_up" : "arrow_drop_down"}
           </span>
         }
@@ -91,6 +93,7 @@ export const AccessRoleDropdown = ({
         onClick={() => {
           onOpenChange?.(!isOpen);
         }}
+        aria-label={ariaLabel}
       >
         {currentRoleString?.label}
       </Button>

--- a/src/components/share/modal/ShareModal.tsx
+++ b/src/components/share/modal/ShareModal.tsx
@@ -158,6 +158,7 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
   const { t } = useCunningham();
   const { isMobile } = useResponsive();
   const searchUserTimeoutRef = useRef<NodeJS.Timeout>(null);
+  const searchContainerRef = useRef<HTMLDivElement>(null);
   const [listHeight, setListHeight] = useState<string>("400px");
   const selectedUsersRef = useRef<HTMLDivElement>(null);
   const [inputValue, setInputValue] = useState<string>("");
@@ -168,6 +169,7 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
   const [selectedInvitationRole, setSelectedInvitationRole] = useState<string>(
     props.invitationRoles?.[0]?.value ?? ""
   );
+  const [pendingAnnouncement, setPendingAnnouncement] = useState<string>("");
 
   /**
    * The height of the modal content
@@ -199,6 +201,22 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
     onSearchUser(str);
   };
 
+  const focusSearchInput = useCallback(() => {
+    requestAnimationFrame(() => {
+      const input = searchContainerRef.current?.querySelector<HTMLInputElement>(
+        "input.quick-search-input",
+      );
+      input?.focus();
+    });
+  }, []);
+
+  // On vide puis on remet le message pour forcer l'annonce SR.
+  // Petit délai pour éviter qu'il soit noyé à la fermeture du menu.
+  const announce = useCallback((message: string) => {
+    setPendingAnnouncement("");
+    setTimeout(() => setPendingAnnouncement(message), 250);
+  }, []);
+
   const showSearchUsers =
     searchQuery !== "" || pendingInvitationUsers.length > 0;
 
@@ -208,13 +226,63 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
       setInputValue("");
       setSearchQuery("");
       props.onSearchUsers!("");
+      announce(
+        t("components.share.user.added", {
+          name: user.full_name || user.email,
+        }),
+      );
+      focusSearchInput();
     },
-    [props]
+    [props, focusSearchInput, t, announce]
   );
 
-  const onRemoveUser = (user: UserData<UserType>) => {
-    setPendingInvitationUsers((prev) => prev.filter((u) => u.id !== user.id));
-  };
+  const onRemoveUser = useCallback(
+    (user: UserData<UserType>) => {
+      setPendingInvitationUsers((prev) => prev.filter((u) => u.id !== user.id));
+      announce(
+        t("components.share.user.removed", {
+          name: user.full_name || user.email,
+        }),
+      );
+      focusSearchInput();
+    },
+    [focusSearchInput, t, announce],
+  );
+
+  const handleUpdateInvitation = useCallback(
+    (
+      invitation: InvitationData<UserType, InvitationType>,
+      role: string,
+    ) => {
+      props.onUpdateInvitation?.(invitation, role);
+      const roleLabel =
+        props.invitationRoles?.find((r) => r.value === role)?.label ?? role;
+      announce(
+        t("components.share.access.role_changed", {
+          name: invitation.email,
+          role: roleLabel,
+        }),
+      );
+    },
+    [props, t, announce],
+  );
+
+  const handleUpdateAccess = useCallback(
+    (access: AccessData<UserType, AccessType>, role: string) => {
+      props.onUpdateAccess?.(access, role);
+      const accessRoles =
+        props.getAccessRoles?.(access) ?? props.invitationRoles ?? [];
+      const roleLabel =
+        accessRoles.find((r) => r.value === role)?.label ?? role;
+      announce(
+        t("components.share.access.role_changed", {
+          name: access.user.full_name || access.user.email,
+          role: roleLabel,
+        }),
+      );
+    },
+    [props, t, announce],
+  );
 
   const usersData: QuickSearchData<UserData<UserType>> = useMemo(() => {
     const searchMemberResult = searchUsersResult?.filter(
@@ -315,7 +383,15 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
       closeOnClickOutside
       size={isMobile ? ModalSize.FULL : ModalSize.LARGE}
     >
-      <div className="c__share-modal no-padding">
+      <div className="c__share-modal no-padding" ref={searchContainerRef}>
+        <div
+          className="c__share-modal__sr-status"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {pendingAnnouncement}
+        </div>
         {canUpdate && pendingInvitationUsers.length > 0 && (
           <div
             className="c__share-modal__selected-users"
@@ -392,15 +468,15 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
                   className="c__share-modal__invitations"
                   data-testid="invitations-list"
                 >
-                  <span className="c__share-modal__invitations-title">
+                  <h3 className="c__share-modal__invitations-title">
                     {t("components.share.invitations.title")}
-                  </span>
+                  </h3>
                   {invitations.map((invitation) => (
                     <ShareInvitationItem
                       key={invitation.id}
                       invitation={invitation}
                       roles={props.invitationRoles!}
-                      updateRole={props.onUpdateInvitation}
+                      updateRole={handleUpdateInvitation}
                       deleteInvitation={props.onDeleteInvitation}
                       canUpdate={canUpdate}
                       roleTopMessage={props.invitationRoleTopMessage?.(
@@ -411,6 +487,7 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
                   <ShowMoreButton
                     show={hasNextInvitations}
                     onShowMore={props.onLoadNextInvitations}
+                    aria-label={t("components.share.invitations.load_more_aria")}
                   />
                 </div>
               )}
@@ -421,7 +498,7 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
                   className="c__share-modal__members"
                   data-testid="members-list"
                 >
-                  <span className="c__share-modal__members-title">
+                  <h3 className="c__share-modal__members-title">
                     {t(
                       members.length > 1
                         ? "components.share.members.title_plural"
@@ -430,7 +507,7 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
                         count: members.length,
                       }
                     )}
-                  </span>
+                  </h3>
                   {members.map((member) => (
                     <ShareMemberItem
                       key={member.id}
@@ -441,13 +518,14 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
                       roles={
                         props.getAccessRoles?.(member) ?? props.invitationRoles!
                       }
-                      updateRole={props.onUpdateAccess}
+                      updateRole={handleUpdateAccess}
                       deleteAccess={props.onDeleteAccess}
                     />
                   ))}
                   <ShowMoreButton
                     show={hasNextMembers}
                     onShowMore={props.onLoadNextMembers}
+                    aria-label={t("components.share.members.load_more_aria")}
                   />
                 </div>
               )}
@@ -485,9 +563,10 @@ export const ShareModal = <UserType, InvitationType, AccessType>({
 type ShowMoreButtonProps = {
   show: boolean;
   onShowMore?: () => void;
+  "aria-label"?: string;
 };
 
-const ShowMoreButton = ({ show, onShowMore }: ShowMoreButtonProps) => {
+const ShowMoreButton = ({ show, onShowMore, "aria-label": ariaLabel }: ShowMoreButtonProps) => {
   const { t } = useCunningham();
   if (!show) return null;
   return (
@@ -495,8 +574,9 @@ const ShowMoreButton = ({ show, onShowMore }: ShowMoreButtonProps) => {
       <Button
         variant="tertiary"
         size="small"
-        icon={<span className="material-icons">arrow_downward</span>}
+        icon={<span className="material-icons" aria-hidden="true">arrow_downward</span>}
         onClick={onShowMore}
+        aria-label={ariaLabel}
       >
         {t("components.share.members.load_more")}
       </Button>

--- a/src/components/share/modal/items/SearchUserItem.tsx
+++ b/src/components/share/modal/items/SearchUserItem.tsx
@@ -20,7 +20,7 @@ export const SearchUserItem = <UserType,>({
       right={
         <div className="c__search-user-item-right">
           <span>{t("components.share.item.add")}</span>
-          <span className="material-icons">add</span>
+          <span className="material-icons" aria-hidden="true">add</span>
         </div>
       }
     />

--- a/src/components/share/modal/items/ShareInvitationItem.tsx
+++ b/src/components/share/modal/items/ShareInvitationItem.tsx
@@ -3,6 +3,7 @@ import { InvitationData } from "../../types";
 import { UserRow } from ":/components/users/rows/UserRow";
 import { DropdownMenuOption, useDropdownMenu } from ":/components/dropdown-menu";
 import { AccessRoleDropdown } from "../../access/AccessRoleDropdown";
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 export type ShareInvitationItemProps<UserType, InvitationType> = {
   invitation: InvitationData<UserType, InvitationType>;
@@ -27,6 +28,11 @@ export const ShareInvitationItem = <UserType, InvitationType>({
   roleTopMessage,
 }: ShareInvitationItemProps<UserType, InvitationType>) => {
   const roleDropdown = useDropdownMenu();
+  const { t } = useCunningham();
+  const displayName = invitation.email;
+  const currentRoleLabel = roles.find(
+    (r) => r.value === invitation.role,
+  )?.label;
 
   return (
     <div className="c__share-member-item">
@@ -49,6 +55,10 @@ export const ShareInvitationItem = <UserType, InvitationType>({
                   ? () => deleteInvitation(invitation)
                   : undefined
               }
+              aria-label={t("components.share.access.role_label", {
+                name: displayName,
+                role: currentRoleLabel ?? "",
+              })}
             />
           </div>
         }

--- a/src/components/share/modal/items/ShareLinkSettings.tsx
+++ b/src/components/share/modal/items/ShareLinkSettings.tsx
@@ -147,7 +147,7 @@ export const ShareLinkSettings = ({
               }}
             >
               {selectedLinkReachChoice?.label}
-              <span className="material-icons">
+              <span className="material-icons" aria-hidden="true">
                 {linkReachDropdown.isOpen ? "arrow_drop_up" : "arrow_drop_down"}
               </span>
             </Button>
@@ -184,7 +184,7 @@ export const ShareLinkSettings = ({
               variant="tertiary"
               data-testid="share-link-role-dropdown-button"
               icon={
-                <span className="material-icons">
+                <span className="material-icons" aria-hidden="true">
                   {linkRoleDropdown.isOpen
                     ? "arrow_drop_up"
                     : "arrow_drop_down"}
@@ -216,9 +216,9 @@ export const ShareLinkSettings = ({
       className="c__share-modal__link-settings"
       data-testid="share-link-settings"
     >
-      <span className="c__share-modal__link-settings__title">
+      <h3 className="c__share-modal__link-settings__title">
         {t("components.share.linkSettings.title")}
-      </span>
+      </h3>
       <div className="c__share-modal__link-settings__content">
         {renderLinkReach()}
         <div className="c__share-modal__link-settings__content__description desktop">

--- a/src/components/share/modal/items/ShareMemberItem.tsx
+++ b/src/components/share/modal/items/ShareMemberItem.tsx
@@ -7,6 +7,7 @@ import {
   useDropdownMenu,
 } from ":/components/dropdown-menu";
 import { AccessRoleDropdown } from "../../access/AccessRoleDropdown";
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 export type ShareMemberItemProps<UserType, AccessType> = {
   accessData: AccessData<UserType, AccessType>;
@@ -28,8 +29,13 @@ export const ShareMemberItem = <UserType, AccessType>({
   roleTopMessage,
 }: ShareMemberItemProps<UserType, AccessType>) => {
   const roleDropdown = useDropdownMenu();
+  const { t } = useCunningham();
   const canDelete =
     accessData.is_explicit !== false && accessData.can_delete !== false;
+  const displayName = accessData.user.full_name || accessData.user.email;
+  const currentRoleLabel = roles.find(
+    (r) => r.value === accessData[accessRoleKey],
+  )?.label;
   return (
     <div className="c__share-member-item">
       <QuickSearchItemTemplate
@@ -56,6 +62,10 @@ export const ShareMemberItem = <UserType, AccessType>({
               onDelete={
                 deleteAccess ? () => deleteAccess(accessData) : undefined
               }
+              aria-label={t("components.share.access.role_label", {
+                name: displayName,
+                role: currentRoleLabel ?? "",
+              })}
             />
           </div>
         }

--- a/src/components/share/modal/share-modal.scss
+++ b/src/components/share/modal/share-modal.scss
@@ -4,6 +4,18 @@
 
 $md: map.get($themes, "default", "globals", "breakpoints", "md");
 
+.c__share-modal__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .c__share-modal__members {
   display: flex;
   flex-direction: column;
@@ -28,6 +40,7 @@ $md: map.get($themes, "default", "globals", "breakpoints", "md");
 .c__share-modal__invitations-title {
   font-size: var(--c--globals--font--sizes--sm);
   font-weight: 700;
+  margin-top: 0;
   margin-bottom: var(--c--globals--spacings--4xs);
   color: var(--c--contextuals--content--semantic--neutral--primary);
 }
@@ -57,6 +70,7 @@ $md: map.get($themes, "default", "globals", "breakpoints", "md");
   &__title {
     font-size: var(--c--globals--font--sizes--sm);
     font-weight: 700;
+    margin-top: 0;
     margin-bottom: var(--c--globals--spacings--4xs);
     color: var(--c--contextuals--content--semantic--neutral--primary);
   }

--- a/src/components/share/users-invitation/InvitationUserSelectorList.tsx
+++ b/src/components/share/users-invitation/InvitationUserSelectorList.tsx
@@ -66,15 +66,18 @@ export const InvitationUserSelectorItem = <UserType,>({
   user,
   onRemoveUser,
 }: ShareSelectedUserItemProps<UserType>) => {
+  const { t } = useCunningham();
+  const displayName = user.full_name || user.email;
   return (
     <div className="c__add-share-user-item" data-testid="selected-user-item">
-      <span>{user.full_name || user.email}</span>
+      <span>{displayName}</span>
       <Button
         variant="tertiary"
         color="neutral"
         size="nano"
         onClick={() => onRemoveUser?.(user)}
-        icon={<span className="material-icons">close</span>}
+        icon={<span className="material-icons" aria-hidden="true">close</span>}
+        aria-label={t("components.share.access.remove_user", { name: displayName })}
       />
     </div>
   );

--- a/src/components/share/utils/ShareModalCopyLinkFooter.tsx
+++ b/src/components/share/utils/ShareModalCopyLinkFooter.tsx
@@ -14,7 +14,7 @@ export const ShareModalCopyLinkFooter = ({
     <div className="c__share-modal__copy-link-footer">
       <Button
         variant="secondary"
-        icon={<span className="material-icons">link</span>}
+        icon={<span className="material-icons" aria-hidden="true">link</span>}
         onClick={onCopyLink}
       >
         {t("components.share.copyLink")}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -11,18 +11,23 @@
       "modalAriaLabel": "Share modal",
       
       "access": {
-        "delete": "Remove access"
+        "delete": "Remove access",
+        "remove_user": "Remove {name}",
+        "role_label": "Change role for {name}, currently {role}",
+        "role_changed": "Role changed to {role} for {name}"
       },
       "cannot_view": {
         "message": "You can view this item but you need additional access to view its members or modify the settings."
       },
       "invitations": {
-        "title": "Pending invitations"
+        "title": "Pending invitations",
+        "load_more_aria": "Show more invitations"
       },
       "members": {
         "title_plural": "Shared between {count} people",
         "title_singular": "Shared between {count} person",
-        "load_more": "Show more "
+        "load_more": "Show more ",
+        "load_more_aria": "Show more members"
       },
       "item": {
         "add": "Add"
@@ -33,7 +38,9 @@
       },
       "user": {
         "no_result": "No result",
-        "placeholder": "Search for a user to invite"
+        "placeholder": "Search for a user to invite",
+        "added": "{name} added to invitations",
+        "removed": "{name} removed from invitations"
       },
       "linkSettings": {
         "title": "Link settings",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -10,18 +10,23 @@
       "modalAriaLabel": "Modale de partage",
       "shareButton": "Partager",
       "access": {
-        "delete": "Retirer l'accès"
+        "delete": "Retirer l'accès",
+        "remove_user": "Retirer {name}",
+        "role_label": "Changer le rôle de {name}, actuellement {role}",
+        "role_changed": "Rôle modifié en {role} pour {name}"
       },
       "cannot_view": {
         "message": "Vous pouvez voir cet élément mais vous avez besoin d'un accès supplémentaire pour voir ses membres ou modifier les paramètres."
       },
       "invitations": {
-        "title": "Invitations en attente"
+        "title": "Invitations en attente",
+        "load_more_aria": "Afficher plus d'invitations"
       },
       "members": {
         "title_plural": "Partagé entre {count} personnes",
         "title_singular": "Partagé entre {count} personne",
-        "load_more": "Afficher plus"
+        "load_more": "Afficher plus",
+        "load_more_aria": "Afficher plus de membres"
       },
       "item": {
         "add": "Ajouter"
@@ -32,7 +37,9 @@
       },
       "user": {
         "no_result": "Aucun résultat",
-        "placeholder": "Rechercher un utilisateur à inviter"
+        "placeholder": "Rechercher un utilisateur à inviter",
+        "added": "{name} ajouté aux invitations",
+        "removed": "{name} retiré des invitations"
       },
       "linkSettings": {
         "title": "Paramètres du lien",


### PR DESCRIPTION
## Purpose

Improve **ShareModal** accessibility for **screen readers** and **keyboard** users:
- reduce noisy announcements from decorative UI
- add clear, contextual labels on action controls
- keep focus predictable after invite/member actions
- announce add/remove/role-change feedback even when focus stays on the same control

**What stays on shared primitives:** menu popup semantics and dialog/menu announcement noise are still partly driven by UI kit / Cunningham components. Related work is tracked in [ui-kit PR #210](https://github.com/suitenumerique/ui-kit/pull/210) and [Cunningham PR #390](https://github.com/suitenumerique/cunningham/pull/390).

Three commits on purpose (flow + labels, then icon noise cleanup).

## Proposal

- [x] Add contextual `aria-label`s on role, remove-user, and show-more controls (members vs invitations).
- [x] Return focus to the search input after adding or removing a pending invited user.
- [x] Add a polite live region for add/remove user and role-change confirmations.
- [x] Use a short clear-then-set delay so confirmations are still announced when dropdown close noise happens.
- [x] Expose ShareModal section titles as headings (`h3`) for SR heading navigation.
- [x] Hide decorative Material Icons (`search`, `add`, `close`, `arrow_*`, `link`) with `aria-hidden="true"`.
- [x] Verify role/remove/show-more labels, invite focus flow, live confirmations, icon noise cleanup, and heading navigation.
- [x] Document remaining dropdown-close SR dump after role/reach selection as out of scope for ShareModal; expected to improve with [ui-kit PR #210](https://github.com/suitenumerique/ui-kit/pull/210) (`role="menu"` + trigger ARIA instead of dialog popup semantics).