### PR TITLE
🐛(tree-view) remove pointer-events rules breaking drag-and-drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - ✨(filter) add custom sub-element support to options
 - ✨(help-menu) add legal links and custom options
 - ✨(front) add SmartScroller component
+- 🐛(tree-view) remove pointer-events rules breaking drag-and-drop #215
 
 ## 0.23.2
 

--- a/src/components/tree-view/index.scss
+++ b/src/components/tree-view/index.scss
@@ -30,7 +30,6 @@
 
 .c__tree-view--row {
   outline: none;
-  pointer-events: none;
 
   &:focus-visible .c__tree-view--node {
     box-shadow: 0 0 0 2px
@@ -91,7 +90,6 @@
   border: 1.5px solid rgba(0, 0, 0, 0);
   cursor: pointer;
   padding: var(--c--globals--spacings--4xs) 0;
-  pointer-events: auto;
   gap: var(--c--globals--spacings--3xs);
 
   &.simpleNode {


### PR DESCRIPTION
## Summary

Remove `pointer-events: none` / `auto` from the tree-view row/node CSS so react-arborist DnD works again (regression from #126).

issue https://github.com/suitenumerique/ui-kit/issues/213