### PR TITLE
✨(front) add headerRightContentEnd slot to FilePreview

### DIFF
--- a/e2e/file-preview/file-preview-header-slots.spec.tsx
+++ b/e2e/file-preview/file-preview-header-slots.spec.tsx
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TestFilePreview } from "../helpers/mount-preview";
+import { pdfFile, audioFile } from "../helpers/fixtures";
+
+test.describe("File Preview header right slots", () => {
+  test("Renders headerRightContentEnd at the end of the right action group", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestFilePreview
+        files={[pdfFile]}
+        handleDownloadFile={() => {}}
+        headerRightContent={
+          <span data-testid="header-right-start">start-slot</span>
+        }
+        headerRightContentEnd={
+          <button data-testid="header-right-end" type="button">
+            end-slot
+          </button>
+        }
+      />,
+    );
+
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const startSlot = page.getByTestId("header-right-start");
+    const endSlot = page.getByTestId("header-right-end");
+    const moreVert = page
+      .getByTestId("file-preview")
+      .getByText("more_vert")
+      .locator("..");
+
+    await expect(startSlot).toBeVisible();
+    await expect(endSlot).toBeVisible();
+    await expect(moreVert).toBeVisible();
+
+    // The end slot should be the last child of the right action group,
+    // sitting after the actions (more_vert) menu — and the start slot
+    // should sit before it.
+    const right = page.locator(".file-preview__header__content__right");
+    const lastChild = right.locator(":scope > *").last();
+    const firstChild = right.locator(":scope > *").first();
+
+    await expect(lastChild).toHaveAttribute("data-testid", "header-right-end");
+    await expect(firstChild).toHaveAttribute(
+      "data-testid",
+      "header-right-start",
+    );
+
+    // Sanity-check horizontal order: end slot must be to the right of more_vert.
+    const endBox = await endSlot.boundingBox();
+    const moreVertBox = await moreVert.boundingBox();
+    expect(endBox && moreVertBox).toBeTruthy();
+    expect(endBox!.x).toBeGreaterThan(moreVertBox!.x);
+  });
+
+  test("Renders headerRightContentEnd even when the actions menu is hidden", async ({
+    mount,
+    page,
+  }) => {
+    // Audio files don't show the more_vert actions menu — the trailing slot
+    // should still render.
+    await mount(
+      <TestFilePreview
+        files={[audioFile]}
+        headerRightContentEnd={
+          <button data-testid="header-right-end" type="button">
+            end-slot
+          </button>
+        }
+      />,
+    );
+
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const filePreview = page.getByTestId("file-preview");
+    await expect(filePreview.getByText("more_vert")).not.toBeVisible();
+    await expect(page.getByTestId("header-right-end")).toBeVisible();
+
+    const right = page.locator(".file-preview__header__content__right");
+    const lastChild = right.locator(":scope > *").last();
+    await expect(lastChild).toHaveAttribute("data-testid", "header-right-end");
+  });
+
+  test("Triggers click handlers on nodes passed via headerRightContentEnd", async ({
+    mount,
+    page,
+  }) => {
+    let clicks = 0;
+    await mount(
+      <TestFilePreview
+        files={[pdfFile]}
+        headerRightContentEnd={
+          <button
+            type="button"
+            data-testid="header-right-end"
+            onClick={() => {
+              clicks += 1;
+            }}
+          >
+            end-slot
+          </button>
+        }
+      />,
+    );
+
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByTestId("header-right-end").click();
+
+    await expect(async () => {
+      expect(clicks).toBe(1);
+    }).toPass({ timeout: 5000 });
+  });
+});

--- a/e2e/helpers/mount-preview.tsx
+++ b/e2e/helpers/mount-preview.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CunninghamProvider } from "../../src/components/Provider/Provider";
 import { FilePreview } from "../../src/components/preview/FilePreview";
@@ -8,6 +9,8 @@ interface TestFilePreviewProps {
   initialIndexFile?: number;
   handleDownloadFile?: (file?: FilePreviewType) => void;
   onClose?: () => void;
+  headerRightContent?: ReactNode;
+  headerRightContentEnd?: ReactNode;
 }
 
 export const TestFilePreview = ({
@@ -15,6 +18,8 @@ export const TestFilePreview = ({
   initialIndexFile = 0,
   handleDownloadFile,
   onClose,
+  headerRightContent,
+  headerRightContentEnd,
 }: TestFilePreviewProps) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const openedFileId = files[initialIndexFile]?.id;
@@ -29,6 +34,8 @@ export const TestFilePreview = ({
           pdfWorkerSrc="/pdf.worker.mjs"
           handleDownloadFile={handleDownloadFile}
           onClose={onClose}
+          headerRightContent={headerRightContent}
+          headerRightContentEnd={headerRightContentEnd}
         />
       </CunninghamProvider>
     </QueryClientProvider>

--- a/src/components/preview/FilePreview.tsx
+++ b/src/components/preview/FilePreview.tsx
@@ -70,6 +70,7 @@ interface FilePreviewProps {
   initialIndexFile?: number;
   openedFileId?: string;
   headerRightContent?: React.ReactNode;
+  headerRightContentEnd?: React.ReactNode;
   sidebarContent?: React.ReactNode;
   onChangeFile?: (file?: FilePreviewType) => void;
   onFileOpen?: (file: FilePreviewType) => void;
@@ -88,6 +89,7 @@ export const FilePreview = ({
   openedFileId,
   sidebarContent,
   headerRightContent,
+  headerRightContentEnd,
   onChangeFile,
   onFileOpen,
   handleDownloadFile,
@@ -408,6 +410,7 @@ export const FilePreview = ({
                     />
                   </DropdownMenu>
                 )}
+                {headerRightContentEnd}
               </div>
             </div>
           </div>

--- a/src/components/preview/stories/FilePreviewExample.tsx
+++ b/src/components/preview/stories/FilePreviewExample.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { FilePreview } from "../FilePreview";
 import type { FilePreviewType } from "../types";
@@ -9,11 +9,15 @@ const queryClient = new QueryClient();
 interface FilePreviewExampleProps {
   files: FilePreviewType[];
   initialFileId?: string;
+  headerRightContent?: ReactNode;
+  headerRightContentEnd?: ReactNode;
 }
 
 export const FilePreviewExample = ({
   files,
   initialFileId,
+  headerRightContent,
+  headerRightContentEnd,
 }: FilePreviewExampleProps) => {
   const [openedFileId, setOpenedFileId] = useState<string | undefined>(
     initialFileId ?? files[0]?.id,
@@ -45,6 +49,8 @@ export const FilePreviewExample = ({
           onOpenInEditor={(file) =>
             console.log("[storybook] open in editor", file.id)
           }
+          headerRightContent={headerRightContent}
+          headerRightContentEnd={headerRightContentEnd}
         />
       </div>
     </QueryClientProvider>

--- a/src/components/preview/stories/file-preview.stories.tsx
+++ b/src/components/preview/stories/file-preview.stories.tsx
@@ -120,7 +120,8 @@ import {
  * | `onFileOpen` | `(file: FilePreviewType) => void` | Fires once per file when it becomes visible |
  * | `handleDownloadFile` | `(file?: FilePreviewType) => void` | Enables the download button + menu entry |
  * | `onOpenInEditor` | `(file: FilePreviewType) => void` | Required to render the WOPI "Open in editor" CTA |
- * | `headerRightContent` | `ReactNode` | Custom node injected next to the action buttons |
+ * | `headerRightContent` | `ReactNode` | Custom node injected at the **start** of the right-side action group (before the built-in download/info/actions buttons) |
+ * | `headerRightContentEnd` | `ReactNode` | Custom node appended at the **end** of the right-side action group (after the built-in actions menu) |
  * | `sidebarContent` | `ReactNode` | Content of the right-side info panel (toggled with the `info` button) |
  * | `hideCloseButton` | `boolean?` | Remove the top-left close button |
  * | `pdfWorkerSrc` | `string?` | Override the `pdf.worker.mjs` URL passed to `pdfjs-dist` |
@@ -198,7 +199,13 @@ const meta: Meta<typeof FilePreview> = {
       control: false,
     },
     headerRightContent: {
-      description: "Custom node injected next to the action buttons",
+      description:
+        "Custom node injected at the start of the right-side action group",
+      control: false,
+    },
+    headerRightContentEnd: {
+      description:
+        "Custom node appended at the end of the right-side action group",
       control: false,
     },
     sidebarContent: {
@@ -318,6 +325,56 @@ export const Suspicious: Story = {
  */
 export const WopiOpenInEditor: Story = {
   render: () => <FilePreviewExample files={[wopiFile]} />,
+};
+
+/**
+ * The header has two slots for custom content on its right side:
+ *
+ * - `headerRightContent` — rendered **before** the built-in download / info /
+ *   actions buttons. Use it for content you want adjacent to the title side
+ *   of the action group (e.g. a status pill, a "shared with…" indicator).
+ * - `headerRightContentEnd` — rendered **after** the actions menu, as the
+ *   last item of the row. Use it for trailing actions you want pinned to the
+ *   far end of the header (e.g. a "Share" button, a custom kebab).
+ *
+ * Both accept any `ReactNode` and stay aligned with the built-in buttons.
+ */
+export const HeaderRightSlots: Story = {
+  render: () => (
+    <FilePreviewExample
+      files={imageFiles}
+      headerRightContent={
+        <span
+          style={{
+            alignSelf: "center",
+            padding: "2px 8px",
+            borderRadius: 999,
+            background: "var(--c--theme--colors--primary-100)",
+            color: "var(--c--theme--colors--primary-700)",
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
+          Shared
+        </span>
+      }
+      headerRightContentEnd={
+        <button
+          type="button"
+          onClick={() => console.log("[storybook] share clicked")}
+          style={{
+            border: "1px solid var(--c--theme--colors--greyscale-300)",
+            borderRadius: 4,
+            padding: "4px 10px",
+            background: "transparent",
+            cursor: "pointer",
+          }}
+        >
+          Share
+        </button>
+      }
+    />
+  ),
 };
 
 /**


### PR DESCRIPTION
## Why

`FilePreview` already exposes `headerRightContent`, but it lands at the **start** of the right-side action group — right before the built-in download / info / actions buttons. That's the wrong anchor for consumers who want a trailing action (a "Share" button, a custom kebab, an export shortcut) pinned to the far end of the header.

Today the only way to get there is to reach into the DOM with CSS — which is fragile and breaks the moment the header layout changes.

## What

Adds a `headerRightContentEnd` prop that mirrors the existing slot but renders **after** the built-in actions menu, as the last child of the right-side row. The two slots are intentionally symmetric so picking the right anchor stays a one-line decision on the consumer side.

```tsx
<FilePreview
  …
  headerRightContent={<StatusPill />}        // before the built-in buttons
  headerRightContentEnd={<ShareButton />}    // after the actions menu
/>
```

## What's in the PR

- `FilePreview.tsx` — new optional prop, rendered as the last node in `.file-preview__header__content__right`.
- Storybook — prop documented in the autodocs table + a dedicated `HeaderRightSlots` story showing both slots side by side.
- Playwright e2e — three new tests covering: trailing-slot ordering vs. the actions menu, behaviour when the actions menu is hidden (audio file), and click handlers staying wired.

## Test plan

- [x] `yarn test:ct e2e/file-preview/file-preview-header-slots.spec.tsx` — 9/9 across chromium / webkit / firefox
- [x] `yarn lint` — no new warnings
- [x] `tsc --noEmit` — clean
- [ ] Visual sanity-check in Storybook (`HeaderRightSlots` story)