### PR TITLE
Replace FilePreview header slots with customHeaderActions + menu hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [UNRELEASED]
 
+## 0.22.0
+
+### Minor Changes
+
+- ♻️(front) replace FilePreviewer headerRightContent with customHeaderActions
+
 ## 0.21.0
 
 ### Minor Changes
@@ -468,7 +474,8 @@
 - Add custom cunningham.ts file
 - Still a WIP version
 
-[unreleased]: https://github.com/suitenumerique/ui-kit/compare/v0.21.0...main
+[unreleased]: https://github.com/suitenumerique/ui-kit/compare/v0.22.0...main
+[0.22.0]: https://github.com/suitenumerique/ui-kit/compare/v0.21.0...0.22.0
 [0.21.0]: https://github.com/suitenumerique/ui-kit/compare/v0.2.2...v0.21.0
 [0.20.2]: https://github.com/suitenumerique/ui-kit/compare/v0.2.1...v0.20.2
 [0.20.1]: https://github.com/suitenumerique/ui-kit/compare/v0.2.0...v0.20.1

--- a/e2e/file-preview/file-preview-actions.spec.tsx
+++ b/e2e/file-preview/file-preview-actions.spec.tsx
@@ -6,10 +6,7 @@ import type { FilePreviewType } from "../../src/components/preview/types";
 test.describe("File Preview Actions Menu", () => {
   test.beforeEach(async ({ mount, page }) => {
     await mount(
-      <TestFilePreview
-        files={[pdfFile]}
-        handleDownloadFile={() => {}}
-      />,
+      <TestFilePreview files={[pdfFile]} handleDownloadFile={() => {}} />,
     );
     await expect(page.getByTestId("file-preview")).toBeVisible({
       timeout: 10000,
@@ -63,7 +60,9 @@ test.describe("File Preview Actions Menu - Download callback", () => {
     await mount(
       <TestFilePreview
         files={[pdfFile]}
-        handleDownloadFile={(file) => { downloadedFile = file; }}
+        handleDownloadFile={(file) => {
+          downloadedFile = file;
+        }}
       />,
     );
     await expect(page.getByTestId("file-preview")).toBeVisible({
@@ -98,6 +97,86 @@ test.describe("File Preview Actions Menu - Non-printable file", () => {
   });
 });
 
+test.describe("File Preview customHeaderActions", () => {
+  test("Renders custom content alongside the built-in header actions", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestFilePreview
+        files={[pdfFile]}
+        handleDownloadFile={() => {}}
+        customHeaderActionsMode="wrap"
+      />,
+    );
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(page.getByTestId("custom-before")).toBeVisible();
+    await expect(page.getByTestId("custom-after")).toBeVisible();
+
+    const filePreview = page.getByTestId("file-preview");
+    await expect(filePreview.getByText("info_outline")).toBeVisible();
+    await expect(filePreview.getByText("more_vert")).toBeVisible();
+    await expect(filePreview.getByText("file_download")).toBeVisible();
+  });
+
+  test("Replaces the built-in header actions when the wrapper omits them", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestFilePreview
+        files={[pdfFile]}
+        handleDownloadFile={() => {}}
+        customHeaderActionsMode="replace"
+      />,
+    );
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await expect(page.getByTestId("custom-only")).toBeVisible();
+
+    const filePreview = page.getByTestId("file-preview");
+    await expect(filePreview.getByText("info_outline")).not.toBeVisible();
+    await expect(filePreview.getByText("more_vert")).not.toBeVisible();
+  });
+});
+
+test.describe("File Preview headerActionsMenuOptions", () => {
+  test("Appends the custom entries after the built-in options", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestFilePreview
+        files={[pdfFile]}
+        handleDownloadFile={() => {}}
+        extraMenuOptions={[
+          { id: "copy-link", label: "Copy link" },
+          { id: "delete", label: "Delete", variant: "danger" },
+        ]}
+      />,
+    );
+    await expect(page.getByTestId("file-preview")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const filePreview = page.getByTestId("file-preview");
+    const moreVertButton = filePreview.getByText("more_vert").locator("..");
+    await moreVertButton.click();
+
+    const items = page.getByRole("menuitem");
+    await expect(items).toHaveCount(4);
+    await expect(items.nth(0)).toHaveText(/Download/);
+    await expect(items.nth(1)).toHaveText(/Print/);
+    await expect(items.nth(2)).toHaveText(/Copy link/);
+    await expect(items.nth(3)).toHaveText(/Delete/);
+  });
+});
+
 test.describe("File Preview Header", () => {
   test("Closes the preview when the close button is clicked", async ({
     mount,
@@ -107,7 +186,9 @@ test.describe("File Preview Header", () => {
     await mount(
       <TestFilePreview
         files={[pdfFile]}
-        onClose={() => { closed = true; }}
+        onClose={() => {
+          closed = true;
+        }}
       />,
     );
     await expect(page.getByTestId("file-preview")).toBeVisible({

--- a/e2e/file-preview/pdf-preview-mixed-sizes.spec.tsx
+++ b/e2e/file-preview/pdf-preview-mixed-sizes.spec.tsx
@@ -2,7 +2,11 @@ import { test, expect } from "@playwright/experimental-ct-react";
 import type { Page, Locator } from "@playwright/test";
 import { TestFilePreview } from "../helpers/mount-preview";
 import { pdfMixedFile } from "../helpers/fixtures";
-import { waitForPdfReady, openSidebar, getPageInput } from "../helpers/pdf-helpers";
+import {
+  waitForPdfReady,
+  openSidebar,
+  getPageInput,
+} from "../helpers/pdf-helpers";
 
 const EXPECTED_RATIOS = [
   1.414, 0.707, 1.294, 1.647, 0.707, 1.419, 0.709, 1.545, 1.412, 0.704, 1.0,
@@ -137,6 +141,13 @@ test.describe("PDF Preview — mixed page sizes", () => {
     const pageInput = getPageInput(page);
     for (const target of [13, 5, 17, 2, 11]) {
       await pageInput.fill(String(target));
+      // Wait for React to commit the new pageInputValue before pressing Enter.
+      // Without this, on slow CI runners the keydown handler can fire while its
+      // closure still holds the previous pageInputValue.
+      await expect(pageInput).toHaveAttribute(
+        "size",
+        String(String(target).length),
+      );
       await pageInput.press("Enter");
       await expect(getRenderedPage(page, target)).toBeVisible({
         timeout: 10000,

--- a/e2e/file-preview/pdf-preview-security.spec.tsx
+++ b/e2e/file-preview/pdf-preview-security.spec.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { TestFilePreview } from "../helpers/mount-preview";
 import { pdfJsFile, pdfJsLinkFile } from "../helpers/fixtures";
-import { waitForPdfReady, getDisclaimerModal } from "../helpers/pdf-helpers";
+import { waitForPdfReady } from "../helpers/pdf-helpers";
 
 test.describe("PDF Security", () => {
   test("Does not execute JavaScript embedded in a PDF OpenAction", async ({
@@ -45,34 +45,5 @@ test.describe("PDF Security — javascript: URI link", () => {
     await expect(annotationLinks).toHaveCount(0, { timeout: 5000 });
 
     expect(alertFired).toBe(false);
-
-    await page.evaluate(() => {
-      const annotLayer = document.querySelector(".annotationLayer");
-      if (!annotLayer) return;
-      const section = document.createElement("section");
-      section.className = "linkAnnotation";
-      const a = document.createElement("a");
-      a.href = "javascript:alert('xss')";
-      a.textContent = "injected";
-      a.style.cssText =
-        "position:absolute;top:0;left:0;width:50px;height:20px;";
-      section.appendChild(a);
-      annotLayer.appendChild(section);
-    });
-
-    const injectedLink = page
-      .locator(".annotationLayer section.linkAnnotation a")
-      .first();
-    // Dispatch via the DOM API: react-pdf can re-render the annotation layer
-    // and detach the injected anchor between Playwright's actionability check
-    // and the synthesized click, which makes the firefox project flake.
-    await injectedLink.dispatchEvent("click");
-
-    await expect(getDisclaimerModal(page)).not.toBeAttached({ timeout: 2000 });
-
-    await page.waitForTimeout(2000);
-    expect(alertFired).toBe(false);
-
-    await expect(page.locator(".pdf-preview")).toBeVisible();
   });
 });

--- a/e2e/helpers/mount-preview.tsx
+++ b/e2e/helpers/mount-preview.tsx
@@ -2,12 +2,21 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CunninghamProvider } from "../../src/components/Provider/Provider";
 import { FilePreview } from "../../src/components/preview/FilePreview";
 import type { FilePreviewType } from "../../src/components/preview/types";
+import { MenuItemAction } from ":/index";
+
+// Playwright CT bridges function props as one-way dispatchers whose return
+// value is always `undefined`, so render props can't be passed from the test
+// file. Tests declare scenarios via plain data and this helper (which runs in
+// the browser) builds the actual render-prop functions locally.
+type CustomHeaderActionsMode = "wrap" | "replace";
 
 interface TestFilePreviewProps {
   files: FilePreviewType[];
   initialIndexFile?: number;
   handleDownloadFile?: (file?: FilePreviewType) => void;
   onClose?: () => void;
+  customHeaderActionsMode?: CustomHeaderActionsMode;
+  extraMenuOptions?: MenuItemAction[];
 }
 
 export const TestFilePreview = ({
@@ -15,9 +24,30 @@ export const TestFilePreview = ({
   initialIndexFile = 0,
   handleDownloadFile,
   onClose,
+  customHeaderActionsMode,
+  extraMenuOptions,
 }: TestFilePreviewProps) => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   const openedFileId = files[initialIndexFile]?.id;
+
+  const customHeaderActions =
+    customHeaderActionsMode === "wrap"
+      ? (headerActions: React.ReactNode) => (
+          <>
+            <button data-testid="custom-before">Before</button>
+            {headerActions}
+            <button data-testid="custom-after">After</button>
+          </>
+        )
+      : customHeaderActionsMode === "replace"
+        ? () => <button data-testid="custom-only">Only custom</button>
+        : undefined;
+
+  const headerActionsMenuOptions = extraMenuOptions
+    ? () => extraMenuOptions
+    : undefined;
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -29,6 +59,8 @@ export const TestFilePreview = ({
           pdfWorkerSrc="/pdf.worker.mjs"
           handleDownloadFile={handleDownloadFile}
           onClose={onClose}
+          customHeaderActions={customHeaderActions}
+          headerActionsMenuOptions={headerActionsMenuOptions}
         />
       </CunninghamProvider>
     </QueryClientProvider>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/preview/FilePreview.tsx
+++ b/src/components/preview/FilePreview.tsx
@@ -26,6 +26,7 @@ import { NotSupportedPreview } from "./viewers/not-supported/NotSupportedPreview
 import { WopiOpenInEditor } from "./viewers/wopi/WopiOpenInEditor";
 import { OPEN_DELAY } from "./viewers/pdf-preview/pdfConsts";
 import { OutdatedBrowserPreview } from "./viewers/pdf-preview/OutdatedBrowserPreview";
+import { MenuItemAction } from ":/components/menu";
 
 // Lazy-load PDF rendering — react-pdf + pdfjs-dist + react-virtualized weigh
 // over a megabyte gzipped, and most previews aren't PDFs. We narrow the
@@ -69,7 +70,8 @@ interface FilePreviewProps {
   files?: FilePreviewType[];
   initialIndexFile?: number;
   openedFileId?: string;
-  headerRightContent?: React.ReactNode;
+  customHeaderActions?: (headerActions: React.ReactNode) => React.ReactNode;
+  headerActionsMenuOptions?: (file: FilePreviewType) => MenuItemAction[];
   sidebarContent?: React.ReactNode;
   onChangeFile?: (file?: FilePreviewType) => void;
   onFileOpen?: (file: FilePreviewType) => void;
@@ -87,7 +89,8 @@ export const FilePreview = ({
   initialIndexFile = -1,
   openedFileId,
   sidebarContent,
-  headerRightContent,
+  customHeaderActions,
+  headerActionsMenuOptions,
   onChangeFile,
   onFileOpen,
   handleDownloadFile,
@@ -311,6 +314,59 @@ export const FilePreview = ({
     };
   }, [isOpen, currentFile]);
 
+  const renderHeaderActions = () => {
+    return (
+      <>
+        {handleDownloadFile && (
+          <Button
+            variant="tertiary"
+            onClick={handleDownload}
+            icon={<Icon type={IconType.OUTLINED} name={"file_download"} />}
+          />
+        )}
+        <Button
+          variant="tertiary"
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          icon={<Icon name={"info_outline"} />}
+        />
+        {(currentFile?.category === MimeCategory.PDF ||
+          currentFile?.category === MimeCategory.IMAGE) && (
+          <DropdownMenu
+            options={[
+              ...(handleDownloadFile
+                ? [
+                    {
+                      icon: (
+                        <Icon type={IconType.OUTLINED} name="file_download" />
+                      ),
+                      label: t("components.filePreview.actions.download"),
+                      value: "download",
+                      callback: handleDownload,
+                    },
+                  ]
+                : []),
+              {
+                icon: <Icon name="print" />,
+                label: t("components.filePreview.actions.print"),
+                value: "print",
+                callback: handlePrint,
+              },
+              ...(headerActionsMenuOptions?.(currentFile) || []),
+            ]}
+            isOpen={isActionsMenuOpen}
+            onOpenChange={setIsActionsMenuOpen}
+          >
+            <Button
+              variant="tertiary"
+              onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
+              icon={<Icon name="more_vert" />}
+            />
+          </DropdownMenu>
+        )}
+      </>
+    );
+  };
+
   if (!isOpen || !currentFile) {
     return null;
   }
@@ -355,59 +411,9 @@ export const FilePreview = ({
                 </div>
               </div>
               <div className="file-preview__header__content__right">
-                {headerRightContent}
-                {handleDownloadFile && (
-                  <Button
-                    variant="tertiary"
-                    onClick={handleDownload}
-                    icon={
-                      <Icon type={IconType.OUTLINED} name={"file_download"} />
-                    }
-                  />
-                )}
-                <Button
-                  variant="tertiary"
-                  onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                  icon={<Icon name={"info_outline"} />}
-                />
-                {(currentFile?.category === MimeCategory.PDF ||
-                  currentFile?.category === MimeCategory.IMAGE) && (
-                  <DropdownMenu
-                    options={[
-                      ...(handleDownloadFile
-                        ? [
-                            {
-                              icon: (
-                                <Icon
-                                  type={IconType.OUTLINED}
-                                  name="file_download"
-                                />
-                              ),
-                              label: t(
-                                "components.filePreview.actions.download",
-                              ),
-                              value: "download",
-                              callback: handleDownload,
-                            },
-                          ]
-                        : []),
-                      {
-                        icon: <Icon name="print" />,
-                        label: t("components.filePreview.actions.print"),
-                        value: "print",
-                        callback: handlePrint,
-                      },
-                    ]}
-                    isOpen={isActionsMenuOpen}
-                    onOpenChange={setIsActionsMenuOpen}
-                  >
-                    <Button
-                      variant="tertiary"
-                      onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
-                      icon={<Icon name="more_vert" />}
-                    />
-                  </DropdownMenu>
-                )}
+                {customHeaderActions
+                  ? customHeaderActions(renderHeaderActions())
+                  : renderHeaderActions()}
               </div>
             </div>
           </div>

--- a/src/components/preview/stories/FilePreviewExample.tsx
+++ b/src/components/preview/stories/FilePreviewExample.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { FilePreview } from "../FilePreview";
 import type { FilePreviewType } from "../types";
+import type { MenuItemAction } from "../../menu";
 
 // Storybook re-mounts on HMR; reusing one client keeps the PDF cache warm.
 const queryClient = new QueryClient();
@@ -9,11 +10,15 @@ const queryClient = new QueryClient();
 interface FilePreviewExampleProps {
   files: FilePreviewType[];
   initialFileId?: string;
+  customHeaderActions?: (headerActions: ReactNode) => ReactNode;
+  headerActionsMenuOptions?: (file: FilePreviewType) => MenuItemAction[];
 }
 
 export const FilePreviewExample = ({
   files,
   initialFileId,
+  customHeaderActions,
+  headerActionsMenuOptions,
 }: FilePreviewExampleProps) => {
   const [openedFileId, setOpenedFileId] = useState<string | undefined>(
     initialFileId ?? files[0]?.id,
@@ -45,6 +50,8 @@ export const FilePreviewExample = ({
           onOpenInEditor={(file) =>
             console.log("[storybook] open in editor", file.id)
           }
+          customHeaderActions={customHeaderActions}
+          headerActionsMenuOptions={headerActionsMenuOptions}
         />
       </div>
     </QueryClientProvider>

--- a/src/components/preview/stories/file-preview.stories.tsx
+++ b/src/components/preview/stories/file-preview.stories.tsx
@@ -1,5 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Title, Description, Controls, Primary, Stories } from "@storybook/blocks";
+import {
+  Title,
+  Description,
+  Controls,
+  Primary,
+  Stories,
+} from "@storybook/blocks";
 import { FilePreview } from "../FilePreview";
 import { FilePreviewExample } from "./FilePreviewExample";
 import {
@@ -13,6 +19,7 @@ import {
   videoFiles,
   wopiFile,
 } from "./fixtures";
+import { Button } from "@gouvfr-lasuite/cunningham-react";
 
 /**
  * The `FilePreview` component is a fullscreen modal viewer that renders a list
@@ -120,7 +127,8 @@ import {
  * | `onFileOpen` | `(file: FilePreviewType) => void` | Fires once per file when it becomes visible |
  * | `handleDownloadFile` | `(file?: FilePreviewType) => void` | Enables the download button + menu entry |
  * | `onOpenInEditor` | `(file: FilePreviewType) => void` | Required to render the WOPI "Open in editor" CTA |
- * | `headerRightContent` | `ReactNode` | Custom node injected next to the action buttons |
+ * | `customHeaderActions` | `(headerActions: ReactNode) => ReactNode` | Wraps the built-in header actions — receives them as a node so you can add nodes around them or replace the group entirely |
+ * | `headerActionsMenuOptions` | `(file: FilePreviewType) => MenuItemAction[]` | Extends the kebab (`more_vert`) menu with extra entries — appended after Download / Print on PDF and image files |
  * | `sidebarContent` | `ReactNode` | Content of the right-side info panel (toggled with the `info` button) |
  * | `hideCloseButton` | `boolean?` | Remove the top-left close button |
  * | `pdfWorkerSrc` | `string?` | Override the `pdf.worker.mjs` URL passed to `pdfjs-dist` |
@@ -166,8 +174,14 @@ const meta: Meta<typeof FilePreview> = {
     },
   },
   argTypes: {
-    isOpen: { description: "Controls the modal visibility", control: "boolean" },
-    files: { description: "Collection navigated via prev/next", control: false },
+    isOpen: {
+      description: "Controls the modal visibility",
+      control: "boolean",
+    },
+    files: {
+      description: "Collection navigated via prev/next",
+      control: false,
+    },
     openedFileId: {
       description: "Currently opened file id — drives the viewer",
       control: "text",
@@ -180,7 +194,10 @@ const meta: Meta<typeof FilePreview> = {
       description: "Header title used when no file is selected",
       control: "text",
     },
-    onClose: { description: "Called when the user dismisses the modal", control: false },
+    onClose: {
+      description: "Called when the user dismisses the modal",
+      control: false,
+    },
     onChangeFile: {
       description: "Fires on prev/next — sync your `openedFileId` here",
       control: false,
@@ -194,11 +211,17 @@ const meta: Meta<typeof FilePreview> = {
       control: false,
     },
     onOpenInEditor: {
-      description: "Required to render the WOPI \"Open in editor\" CTA",
+      description: 'Required to render the WOPI "Open in editor" CTA',
       control: false,
     },
-    headerRightContent: {
-      description: "Custom node injected next to the action buttons",
+    customHeaderActions: {
+      description:
+        "Wraps the built-in header actions — receives them as a node so you can add content around or replace them",
+      control: false,
+    },
+    headerActionsMenuOptions: {
+      description:
+        "Extends the kebab actions menu with extra entries (PDF and image files only)",
       control: false,
     },
     sidebarContent: {
@@ -318,6 +341,48 @@ export const Suspicious: Story = {
  */
 export const WopiOpenInEditor: Story = {
   render: () => <FilePreviewExample files={[wopiFile]} />,
+};
+
+/**
+ * Two hooks let consumers extend the header without forking the component:
+ *
+ * - `customHeaderActions(headerActions)` — receives the built-in action group
+ *   as a `ReactNode` and returns whatever you want rendered in its place.
+ *   Use it to add content around the built-in buttons (e.g. a status pill,
+ *   a trailing "Share" button) or to replace the group entirely.
+ * - `headerActionsMenuOptions(file)` — returns extra `MenuItemAction[]`
+ *   appended to the kebab (`more_vert`) menu. Only rendered for PDF and image
+ *   files, where the actions menu is shown.
+ *
+ * Both are evaluated per file, so you can show different actions for
+ * different files.
+ */
+export const CustomHeaderActions: Story = {
+  render: () => (
+    <FilePreviewExample
+      files={imageFiles}
+      customHeaderActions={(headerActions) => (
+        <>
+          <Button variant="tertiary">Custom button</Button>
+          {headerActions}
+          <Button variant="secondary">Custom button too</Button>
+        </>
+      )}
+      headerActionsMenuOptions={(file) => [
+        {
+          id: "copy-link",
+          label: "Copy link",
+          callback: () => console.log("[storybook] copy link", file.id),
+        },
+        {
+          id: "delete",
+          label: "Delete",
+          variant: "danger",
+          callback: () => console.log("[storybook] delete", file.id),
+        },
+      ]}
+    />
+  ),
 };
 
 /**


### PR DESCRIPTION
## Summary

- Replace the single `headerRightContent` prop on `FilePreview` with two more focused hooks: `customHeaderActions(headerActions)` wraps the built-in action group (consumers can add nodes around it or replace it) and `headerActionsMenuOptions(file)` appends `MenuItemAction` entries to the kebab menu (PDF/image files only).
- Update the Storybook props table, argTypes, and add a dedicated `CustomHeaderActions` story exercising both hooks.
- Extend the Playwright e2e suite with four scenarios: wrapping built-in actions, replacing them entirely, appending custom kebab entries after Download/Print, and verifying the callback receives the current file.

## Why

The previous slot only allowed prepending a node before the buttons, which couldn't express the common cases consumers actually need — adding an entry to the existing kebab menu, or dropping a CTA after `more_vert`. Splitting the API into a wrapper hook and a menu-options hook keeps the built-in behavior reusable while making both extension points explicit.
