### PR TITLE
Improve dropdown menu accessibility state and focus

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -7,7 +7,17 @@ import {
   SubmenuTrigger,
 } from "react-aria-components";
 import { DropdownMenuItem, DropdownMenuOption } from "./types";
-import { Fragment, PropsWithChildren, ReactNode, useId, useRef } from "react";
+import {
+  Children,
+  cloneElement,
+  Fragment,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  useId,
+  useRef,
+} from "react";
 import { MenuItemSeparator } from "../menu/types";
 import clsx from "clsx";
 
@@ -58,6 +68,7 @@ export const DropdownMenu = ({
   variant = "default",
 }: PropsWithChildren<DropdownMenuProps>) => {
   const id = useId();
+  const menuId = `${id}-menu`;
   const triggerRef = useRef(null);
   const menuClassName = `c__dropdown-menu${
     variant === "tiny" ? " c__dropdown-menu--tiny" : ""
@@ -134,6 +145,15 @@ export const DropdownMenu = ({
       );
     });
 
+  const triggerChildren =
+    Children.count(children) === 1 && isValidElement(children)
+      ? cloneElement(children as ReactElement<Record<string, unknown>>, {
+          "aria-controls": isOpen ? menuId : undefined,
+          "aria-expanded": isOpen,
+          "aria-haspopup": "menu",
+        })
+      : children;
+
   return (
     <>
       <div
@@ -145,7 +165,7 @@ export const DropdownMenu = ({
           e.preventDefault();
         }}
       >
-        {children}
+        {triggerChildren}
       </div>
 
       <Popover
@@ -159,7 +179,12 @@ export const DropdownMenu = ({
         shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         onOpenChange={onOpenChangeHandler}
       >
-        <Menu className={menuClassName} aria-labelledby={id} autoFocus="first">
+        <Menu
+          className={menuClassName}
+          id={menuId}
+          aria-labelledby={id}
+          autoFocus="first"
+        >
           {topMessage && (
             <Header
               className="c__dropdown-menu-item-top-message"

--- a/src/components/dropdown-menu/index.scss
+++ b/src/components/dropdown-menu/index.scss
@@ -103,6 +103,12 @@
     );
   }
 
+  &[data-focused] {
+    outline: 2px solid
+      var(--c--contextuals--border--semantic--brand--primary, #5e5cd0);
+    outline-offset: -2px;
+  }
+
   &[data-disabled] {
     color: var(--c--contextuals--content--semantic--disabled--primary);
     cursor: not-allowed;


### PR DESCRIPTION
## Summary

This PR addresses part of #183 for `DropdownMenu` by improving the trigger state announcement and keyboard focus visibility.

Changes:
- add `aria-haspopup="menu"` and `aria-expanded` to a single trigger element when possible
- link the trigger to the menu with `aria-controls` while the menu is open
- add an explicit high-contrast outline for focused menu items, instead of relying only on a very subtle background change

## Accessibility impact

Screen-reader users can now hear whether the dropdown trigger is expanded or collapsed, and keyboard users get a clearer focus indicator while navigating menu items.

This is intentionally a small, safe step toward the broader dropdown accessibility issue rather than a full rewrite of the component.

## Validation

- `corepack yarn lint` — passed with existing warnings in unrelated preview components
- `corepack yarn build` — passed

Closes part of #183.
