### PR TITLE
Fix dropdown trigger accessibility state

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -7,7 +7,16 @@ import {
   SubmenuTrigger,
 } from "react-aria-components";
 import { DropdownMenuItem, DropdownMenuOption } from "./types";
-import { Fragment, PropsWithChildren, ReactNode, useId, useRef } from "react";
+import {
+  cloneElement,
+  Fragment,
+  isValidElement,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  useId,
+  useRef,
+} from "react";
 import { MenuItemSeparator } from "../menu/types";
 import clsx from "clsx";
 
@@ -59,11 +68,27 @@ export const DropdownMenu = ({
 }: PropsWithChildren<DropdownMenuProps>) => {
   const id = useId();
   const triggerRef = useRef(null);
+  const menuId = `${id}-menu`;
   const menuClassName = `c__dropdown-menu${
     variant === "tiny" ? " c__dropdown-menu--tiny" : ""
   }`;
   const onOpenChangeHandler = (isOpen: boolean) => {
     onOpenChange?.(isOpen);
+  };
+
+  const renderTrigger = (children: ReactNode) => {
+    if (!isValidElement(children)) {
+      return children;
+    }
+
+    const triggerElement = children as ReactElement<Record<string, unknown>>;
+
+    return cloneElement(triggerElement, {
+      ...triggerElement.props,
+      "aria-controls": isOpen ? menuId : undefined,
+      "aria-expanded": isOpen,
+      "aria-haspopup": "menu",
+    });
   };
 
   const renderMenuItems = (items: DropdownMenuItem[]) =>
@@ -145,7 +170,7 @@ export const DropdownMenu = ({
           e.preventDefault();
         }}
       >
-        {children}
+        {renderTrigger(children)}
       </div>
 
       <Popover
@@ -159,7 +184,12 @@ export const DropdownMenu = ({
         shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         onOpenChange={onOpenChangeHandler}
       >
-        <Menu className={menuClassName} aria-labelledby={id} autoFocus="first">
+        <Menu
+          id={menuId}
+          className={menuClassName}
+          aria-labelledby={id}
+          autoFocus="first"
+        >
           {topMessage && (
             <Header
               className="c__dropdown-menu-item-top-message"


### PR DESCRIPTION
## Summary
- add `aria-haspopup="menu"` and `aria-expanded` to the dropdown trigger element
- connect the trigger to the rendered menu with `aria-controls` while the menu is open
- add a stable id to the menu element used by that relationship

## Accessibility impact
This addresses one concrete part of #183: screen reader users can now hear that the trigger opens a menu and whether it is currently expanded. Keyboard and screen reader users get a clearer state announcement before moving into the menu.

## Validation
- `corepack yarn eslint src/components/dropdown-menu/DropdownMenu.tsx --report-unused-disable-directives`
- `corepack yarn build`

Closes part of #183.
