### PR TITLE
Improve dropdown menu accessibility state

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -58,6 +58,7 @@ export const DropdownMenu = ({
   variant = "default",
 }: PropsWithChildren<DropdownMenuProps>) => {
   const id = useId();
+  const menuId = `${id}-menu`;
   const triggerRef = useRef(null);
   const menuClassName = `c__dropdown-menu${
     variant === "tiny" ? " c__dropdown-menu--tiny" : ""
@@ -77,6 +78,12 @@ export const DropdownMenu = ({
       }
 
       const itemKey = option.id || option.label;
+      const isSelectable =
+        option.value !== undefined || option.isChecked !== undefined;
+      const isSelected = Boolean(
+        option.isChecked ||
+          (option.value && selectedValues.includes(option.value))
+      );
 
       if (hasChildren(option)) {
         return (
@@ -86,6 +93,7 @@ export const DropdownMenu = ({
                 "c__dropdown-menu-item--danger": option.variant === "danger",
               })}
               aria-label={option.label}
+              aria-checked={isSelectable ? isSelected : undefined}
               isDisabled={option.isDisabled}
               data-testid={option.testId}
             >
@@ -110,6 +118,7 @@ export const DropdownMenu = ({
               "c__dropdown-menu-item--danger": option.variant === "danger",
             })}
             aria-label={option.label}
+            aria-checked={isSelectable ? isSelected : undefined}
             onAction={() => {
               if (option.value) {
                 onSelectValue?.(option.value);
@@ -123,8 +132,7 @@ export const DropdownMenu = ({
             data-testid={option.testId}
           >
             <MenuItemContent option={option} />
-            {(option.isChecked ||
-              (option.value && selectedValues.includes(option.value))) && (
+            {isSelected && (
               <span className="material-icons checked">check</span>
             )}
           </MenuItem>
@@ -140,6 +148,9 @@ export const DropdownMenu = ({
         className="c__dropdown-menu-trigger"
         ref={triggerRef}
         id={id}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? menuId : undefined}
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();
@@ -159,7 +170,12 @@ export const DropdownMenu = ({
         shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         onOpenChange={onOpenChangeHandler}
       >
-        <Menu className={menuClassName} aria-labelledby={id} autoFocus="first">
+        <Menu
+          id={menuId}
+          className={menuClassName}
+          aria-labelledby={id}
+          autoFocus="first"
+        >
           {topMessage && (
             <Header
               className="c__dropdown-menu-item-top-message"

--- a/src/components/dropdown-menu/index.scss
+++ b/src/components/dropdown-menu/index.scss
@@ -103,6 +103,11 @@
     );
   }
 
+  &[data-focused] {
+    box-shadow: inset 0 0 0 2px
+      var(--c--contextuals--border--semantic--active--primary, #000091);
+  }
+
   &[data-disabled] {
     color: var(--c--contextuals--content--semantic--disabled--primary);
     cursor: not-allowed;


### PR DESCRIPTION
## Summary
- expose the dropdown popover relationship with `aria-haspopup`, `aria-expanded`, and `aria-controls`
- give the menu a stable id connected to the trigger container while open
- expose checked dropdown options with `aria-checked`
- add a high-contrast focus outline for focused dropdown items

## Accessibility impact
This addresses part of #183 by making the open/closed state and checked state available to assistive technologies, and by improving the visible keyboard focus indicator beyond the low-contrast hover/focus background.

## Checks
- `yarn lint` (passes with existing react-hooks warnings in preview components)
- `yarn build`
