### PR TITLE
♿️(layout) use header tag for header instead of div

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -20,7 +20,7 @@ export const Header = ({
 }: HeaderProps) => {
   const { t } = useCunningham();
   return (
-    <div className="c__header">
+    <header className="c__header">
       <div className="c__header__toggle-menu">
         <Button
           size="medium"
@@ -44,6 +44,6 @@ export const Header = ({
 
         {rightIcon}
       </div>
-    </div>
+    </header>
   );
 };


### PR DESCRIPTION
Hi, 

as noted in https://github.com/suitenumerique/dictaphone/issues/68, I suggest we swtich from `div` to `header` html tag for the Header component.