### PR TITLE
♿(i18n) add german and spanish gaufre translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## 0.23.1
 
+### Minor Changes
+
+- ♿(i18n) add german and spanish gaufre translations #242
+
 ### Patch Changes
 
 - 🐛(front) fix export icons files

--- a/README.md
+++ b/README.md
@@ -342,12 +342,15 @@ const customTranslations = {
 
 ## Internationalization
 
-The UI Kit natively supports French and English.
+The UI Kit natively supports French, English, Dutch, German and Spanish.
 
 ### Supported Languages
 
 - `fr-FR` - French (default)
 - `en-US` - English
+- `nl-NL` - Dutch
+- `de-DE` - German
+- `es-ES` - Spanish
 
 ### Changing Language
 

--- a/src/locales/Locale.tsx
+++ b/src/locales/Locale.tsx
@@ -2,15 +2,22 @@ import {enUS as originalEnUS, frFR as originalFrFR} from "@gouvfr-lasuite/cunnin
 import { default as enUS } from "./en-US.json";
 import { default as frFR } from "./fr-FR.json";
 import { default as nlNL } from "./nl-NL.json";
+import { default as deDE } from "./de-DE.json";
+import { default as esES } from "./es-ES.json";
 import { deepMerge } from "../utils/objects";
 
-// Cunningham ships only enUS and frFR. For nl-NL we deep-clone the English
-// Cunningham base, then layer Dutch ui-kit strings on top — avoids mutating
-// the shared originalEnUS object that "en-US" also derives from.
+// Cunningham ships only enUS and frFR. For locales it does not provide
+// (nl-NL, de-DE, es-ES) we deep-clone the English Cunningham base, then layer
+// the localized ui-kit strings on top — avoids mutating the shared
+// originalEnUS object that "en-US" also derives from.
 const nlBase = JSON.parse(JSON.stringify(originalEnUS));
+const deBase = JSON.parse(JSON.stringify(originalEnUS));
+const esBase = JSON.parse(JSON.stringify(originalEnUS));
 
 export const locales = {
     "en-US": deepMerge(originalEnUS, enUS),
     "fr-FR": deepMerge(originalFrFR, frFR),
     "nl-NL": deepMerge(nlBase, nlNL),
+    "de-DE": deepMerge(deBase, deDE),
+    "es-ES": deepMerge(esBase, esES),
 }

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -1,0 +1,158 @@
+{
+  "components": {
+    "share": {
+      "copyLink": "Link kopieren",
+      "ok": "OK",
+      "shareButton": "Teilen",
+      "modalTitle": "Ordner teilen",
+      "modalAriaLabel": "Teilen-Dialog",
+      "access": {
+        "delete": "Zugriff entziehen"
+      },
+      "cannot_view": {
+        "message": "Sie können dieses Element ansehen, benötigen jedoch zusätzlichen Zugriff, um seine Mitglieder zu sehen oder die Einstellungen zu ändern."
+      },
+      "invitations": {
+        "title": "Ausstehende Einladungen"
+      },
+      "members": {
+        "title_plural": "Geteilt mit {count} Personen",
+        "title_singular": "Geteilt mit {count} Person",
+        "load_more": "Mehr anzeigen"
+      },
+      "item": {
+        "add": "Hinzufügen"
+      },
+      "search": {
+        "placeholder": "Benutzer suchen",
+        "group_name": "Suchergebnis für Benutzer"
+      },
+      "user": {
+        "no_result": "Kein Ergebnis",
+        "placeholder": "Nach einem Benutzer zum Einladen suchen"
+      },
+      "linkSettings": {
+        "title": "Link-Einstellungen",
+        "reach": {
+          "choices": {
+            "public": {
+              "title": "Öffentlich",
+              "description": "Jeder mit dem Link kann auf das Dokument zugreifen"
+            },
+            "authenticated": {
+              "title": "Authentifiziert",
+              "description": "Nur authentifizierte Benutzer können auf das Dokument zugreifen"
+            },
+            "restricted": {
+              "title": "Privat",
+              "description": "Nur Benutzer des Bereichs können auf das Dokument zugreifen"
+            }
+          }
+        },
+        "role": {
+          "choices": {
+            "reader": {
+              "title": "Leser"
+            },
+            "editor": {
+              "title": "Bearbeiter"
+            }
+          }
+        }
+      }
+    },
+    "laGaufre": {
+      "label": "Digitale LaSuite-Dienste",
+      "closeLabel": "Menü schließen",
+      "viewMoreLabel": "Mehr anzeigen",
+      "viewLessLabel": "Weniger anzeigen",
+      "loadingText": "Wird geladen…",
+      "newWindowLabelSuffix": " (neues Fenster)",
+      "headerLabel": "Über"
+    },
+    "userMenu": {
+      "term_of_service": "Nutzungsbedingungen",
+      "manage_account": "Konto verwalten",
+      "open": "Benutzermenü öffnen",
+      "close": "Benutzermenü schließen",
+      "accountSettings": "Kontoeinstellungen",
+      "logout": "Abmelden",
+      "dialogTitle": "Benutzermenü"
+    },
+    "treeView": {
+      "viewMore": "Weitere Elemente laden"
+    },
+    "footer": {
+      "logo": {
+        "alt": "Logo der französischen Regierung"
+      }
+    },
+    "onboarding": {
+      "skip": "Überspringen",
+      "next": "Weiter",
+      "previous": "Zurück",
+      "complete": "Verstanden",
+      "stepLabel": "Schritt {current} von {total}: {title}",
+      "currentStepSuffix": " (aktuell)",
+      "contentRegionLabel": "Inhalt von Schritt {current} von {total}"
+    },
+    "feedbackForm": {
+      "title": "Das Team kontaktieren",
+      "subtitle": "Bug, Idee, Frage oder Lob — das Team liest alles und meldet sich bei Bedarf zurück.",
+      "subject": "Betreff",
+      "subjectPlaceholder": "Worum geht es?",
+      "message": "Ihre Nachricht",
+      "messagePlaceholder": "Beschreiben Sie Ihr Problem oder Ihren Vorschlag...",
+      "uploadFile": "Datei hochladen",
+      "emailCheckbox": "Ich möchte eine Antwort per E-Mail erhalten",
+      "emailLabel": "E-Mail",
+      "emailPrivacy": "Sehen, wie Ihre E-Mail-Adresse verwendet wird",
+      "emailError": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+      "cancel": "Abbrechen",
+      "send": "Senden",
+      "category": "Kategorie",
+      "closeAriaLabel": "Kontaktformular schließen"
+    },
+    "filePreview": {
+      "title": "Dateivorschau",
+      "unsupported": {
+        "title": "Nicht unterstützte Datei",
+        "disclaimer": "Format nicht unterstützt.",
+        "description": "Um die Datei anzusehen, laden Sie sie auf Ihr Gerät herunter.",
+        "download": "Datei herunterladen",
+        "heicTitle": "HEIC-Dateien werden für die Vorschau noch nicht unterstützt."
+      },
+      "suspicious": {
+        "title": "Verdächtige Datei",
+        "description": "Diese Datei sieht verdächtig aus. Sie ist nur für Sie sichtbar.",
+        "download": "Datei herunterladen"
+      },
+      "error": {
+        "title": "Beim Laden des Dokuments ist ein Fehler aufgetreten.",
+        "description": "Sie können sich für Hilfe an den Support wenden."
+      },
+      "wopi": {
+        "loading": "Dokument wird geladen...",
+        "error": "Beim Laden des Dokuments ist ein Fehler aufgetreten.",
+        "openInEditor": "Im Editor öffnen",
+        "openInEditorDescription": "Diese Datei kann mit einem Online-Editor bearbeitet werden. Sie wird in einem neuen Tab geöffnet."
+      },
+      "image": {
+        "loading": "Bild wird geladen..."
+      },
+      "externalLink": {
+        "title": "Externer Link",
+        "description": "Sie sind dabei, diese Seite zu verlassen und werden weitergeleitet zu:",
+        "confirmQuestion": "Möchten Sie fortfahren?"
+      },
+      "outdatedBrowser": {
+        "title": "Ihr Browser wird nicht unterstützt",
+        "description": "Aus Sicherheitsgründen erfordert der PDF-Viewer einen aktuellen Browser. Bitte aktualisieren Sie Ihren Browser oder verwenden Sie Firefox oder Chrome."
+      },
+      "actions": {
+        "download": "Herunterladen",
+        "print": "Drucken"
+      }
+    }
+  }
+}

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -1,0 +1,158 @@
+{
+  "components": {
+    "share": {
+      "copyLink": "Copiar enlace",
+      "ok": "OK",
+      "shareButton": "Compartir",
+      "modalTitle": "Compartir carpeta",
+      "modalAriaLabel": "Ventana de compartir",
+      "access": {
+        "delete": "Retirar acceso"
+      },
+      "cannot_view": {
+        "message": "Puede ver este elemento, pero necesita acceso adicional para ver sus miembros o modificar la configuración."
+      },
+      "invitations": {
+        "title": "Invitaciones pendientes"
+      },
+      "members": {
+        "title_plural": "Compartido entre {count} personas",
+        "title_singular": "Compartido entre {count} persona",
+        "load_more": "Mostrar más"
+      },
+      "item": {
+        "add": "Añadir"
+      },
+      "search": {
+        "placeholder": "Buscar usuario",
+        "group_name": "Resultado de la búsqueda de usuario"
+      },
+      "user": {
+        "no_result": "Sin resultados",
+        "placeholder": "Buscar un usuario para invitar"
+      },
+      "linkSettings": {
+        "title": "Configuración del enlace",
+        "reach": {
+          "choices": {
+            "public": {
+              "title": "Público",
+              "description": "Cualquier persona con el enlace puede acceder al documento"
+            },
+            "authenticated": {
+              "title": "Autenticado",
+              "description": "Solo los usuarios autenticados pueden acceder al documento"
+            },
+            "restricted": {
+              "title": "Privado",
+              "description": "Solo los usuarios del espacio pueden acceder al documento"
+            }
+          }
+        },
+        "role": {
+          "choices": {
+            "reader": {
+              "title": "Lector"
+            },
+            "editor": {
+              "title": "Editor"
+            }
+          }
+        }
+      }
+    },
+    "laGaufre": {
+      "label": "Servicios digitales de LaSuite",
+      "closeLabel": "Cerrar el menú",
+      "viewMoreLabel": "Ver más",
+      "viewLessLabel": "Ver menos",
+      "loadingText": "Cargando…",
+      "newWindowLabelSuffix": " (nueva ventana)",
+      "headerLabel": "Acerca de"
+    },
+    "userMenu": {
+      "term_of_service": "Condiciones de uso",
+      "manage_account": "Gestionar la cuenta",
+      "open": "Abrir el menú de usuario",
+      "close": "Cerrar el menú de usuario",
+      "accountSettings": "Configuración de la cuenta",
+      "logout": "Cerrar sesión",
+      "dialogTitle": "Menú de usuario"
+    },
+    "treeView": {
+      "viewMore": "Cargar más elementos"
+    },
+    "footer": {
+      "logo": {
+        "alt": "Logotipo del gobierno francés"
+      }
+    },
+    "onboarding": {
+      "skip": "Omitir",
+      "next": "Siguiente",
+      "previous": "Anterior",
+      "complete": "Entendido",
+      "stepLabel": "Paso {current} de {total}: {title}",
+      "currentStepSuffix": " (actual)",
+      "contentRegionLabel": "Contenido del paso {current} de {total}"
+    },
+    "feedbackForm": {
+      "title": "Contactar con el equipo",
+      "subtitle": "Error, idea, pregunta o felicitación: el equipo lo lee todo y le responderá si es necesario.",
+      "subject": "Asunto",
+      "subjectPlaceholder": "¿De qué se trata?",
+      "message": "Su mensaje",
+      "messagePlaceholder": "Describa su problema o sugerencia...",
+      "uploadFile": "Subir un archivo",
+      "emailCheckbox": "Me gustaría recibir una respuesta por correo electrónico",
+      "emailLabel": "Correo electrónico",
+      "emailPrivacy": "Ver cómo se utiliza su correo electrónico",
+      "emailError": "Introduzca una dirección de correo electrónico válida.",
+      "cancel": "Cancelar",
+      "send": "Enviar",
+      "category": "Categoría",
+      "closeAriaLabel": "Cerrar el formulario de contacto"
+    },
+    "filePreview": {
+      "title": "Vista previa del archivo",
+      "unsupported": {
+        "title": "Archivo no compatible",
+        "disclaimer": "Formato no compatible.",
+        "description": "Para ver el archivo, descárguelo en su dispositivo.",
+        "download": "Descargar archivo",
+        "heicTitle": "Los archivos HEIC aún no son compatibles para la vista previa."
+      },
+      "suspicious": {
+        "title": "Archivo sospechoso",
+        "description": "Este archivo parece sospechoso. Solo es visible para usted.",
+        "download": "Descargar archivo"
+      },
+      "error": {
+        "title": "Se ha producido un error al cargar el documento.",
+        "description": "Puede contactar con el soporte para obtener ayuda."
+      },
+      "wopi": {
+        "loading": "Cargando documento...",
+        "error": "Se ha producido un error al cargar el documento.",
+        "openInEditor": "Abrir en el editor",
+        "openInEditorDescription": "Este archivo se puede editar con un editor en línea. Se abre en una nueva pestaña."
+      },
+      "image": {
+        "loading": "Cargando imagen..."
+      },
+      "externalLink": {
+        "title": "Enlace externo",
+        "description": "Está a punto de salir de esta página y ser redirigido a:",
+        "confirmQuestion": "¿Desea continuar?"
+      },
+      "outdatedBrowser": {
+        "title": "Su navegador no es compatible",
+        "description": "Por razones de seguridad, el visor de PDF requiere un navegador reciente. Actualice su navegador o utilice Firefox o Chrome."
+      },
+      "actions": {
+        "download": "Descargar",
+        "print": "Imprimir"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Improve Suite waffle accessibility and i18n coverage for screen readers:

- ensure the waffle label is translated in German and Spanish interfaces
- expose these languages supported locales in the UI Kit

## Proposal

- Add `de-DE` and `es-ES` locale files with full `components` translation keys (including `components.laGaufre.*`).