### PR TITLE
♿️(menu) add opensInNewWindow for external link aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [UNRELEASED]
 
+### Minor Changes
+
+- ♿️(menu) add opensInNewWindow for external link aria-label #246
+
 ## 0.23.2
 
 ### Minor Changes

--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -15,6 +15,7 @@ import {
   MenuItemAction,
   ContextMenuState,
 } from "./types";
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 const ContextMenuContext = createContext<ContextMenuContextValue | null>(null);
 
@@ -39,6 +40,7 @@ const getItemKey = (item: MenuItemAction, index: number): string => {
 export const ContextMenuProvider = ({ children }: PropsWithChildren) => {
   // Check for nested providers first (but after hook declarations for Rules of Hooks)
   const existingContext = useContext(ContextMenuContext);
+  const { t } = useCunningham();
 
   const [state, setState] = useState<ContextMenuState>({
     isOpen: false,
@@ -187,7 +189,7 @@ export const ContextMenuProvider = ({ children }: PropsWithChildren) => {
                 key={itemKey}
                 id={itemKey}
                 className={`c__dropdown-menu-item${item.variant === "danger" ? " c__dropdown-menu-item--danger" : ""}`}
-                aria-label={item.label}
+                aria-label={item.opensInNewWindow ? item.label + t("components.menu.newWindowLabelSuffix") : item.label}
                 isDisabled={item.isDisabled}
                 data-testid={item.testId || `context-menu-item-${itemKey}`}
               >

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -6,20 +6,21 @@ import {
   Separator,
   SubmenuTrigger,
 } from "react-aria-components";
-import { DropdownMenuItem, DropdownMenuOption } from "./types";
+import { MenuItemAction, MenuItemSeparator } from "../menu/types";
+import { DropdownMenuItem } from "./types";
 import { Fragment, PropsWithChildren, ReactNode, useId, useRef } from "react";
-import { MenuItemSeparator } from "../menu/types";
 import clsx from "clsx";
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 const isSeparator = (item: DropdownMenuItem): item is MenuItemSeparator => {
   return "type" in item && item.type === "separator";
 };
 
-const hasChildren = (item: DropdownMenuOption): boolean => {
+const hasChildren = (item: MenuItemAction): boolean => {
   return Array.isArray(item.children) && item.children.length > 0;
 };
 
-const MenuItemContent = ({ option }: { option: DropdownMenuOption }) => (
+const MenuItemContent = ({ option }: { option: MenuItemAction }) => (
   <>
     {option.icon && (
       <div className="c__dropdown-menu-item__icon">{option.icon}</div>
@@ -59,11 +60,19 @@ export const DropdownMenu = ({
 }: PropsWithChildren<DropdownMenuProps>) => {
   const id = useId();
   const triggerRef = useRef(null);
+  const { t } = useCunningham();
   const menuClassName = `c__dropdown-menu${
     variant === "tiny" ? " c__dropdown-menu--tiny" : ""
   }`;
   const onOpenChangeHandler = (isOpen: boolean) => {
     onOpenChange?.(isOpen);
+  };
+
+  const getAriaLabel = (option: MenuItemAction): string => {
+    if (option.opensInNewWindow) {
+      return option.label + t("components.menu.newWindowLabelSuffix");
+    }
+    return option.label;
   };
 
   const renderMenuItems = (items: DropdownMenuItem[]) =>
@@ -85,7 +94,7 @@ export const DropdownMenu = ({
               className={clsx("c__dropdown-menu-item", {
                 "c__dropdown-menu-item--danger": option.variant === "danger",
               })}
-              aria-label={option.label}
+              aria-label={getAriaLabel(option)}
               isDisabled={option.isDisabled}
               data-testid={option.testId}
             >
@@ -109,7 +118,7 @@ export const DropdownMenu = ({
             className={clsx("c__dropdown-menu-item", {
               "c__dropdown-menu-item--danger": option.variant === "danger",
             })}
-            aria-label={option.label}
+            aria-label={getAriaLabel(option)}
             onAction={() => {
               if (option.value) {
                 onSelectValue?.(option.value);

--- a/src/components/dropdown-menu/dropdown.stories.tsx
+++ b/src/components/dropdown-menu/dropdown.stories.tsx
@@ -46,6 +46,7 @@ import { useState } from "react";
  * | `variant` | `"default" \| "danger"` | Item style (danger = red) |
  * | `value` | `string` | Value for selection mode |
  * | `isChecked` | `boolean` | Shows a checkmark |
+ * | `opensInNewWindow` | `boolean` | Appends "(new window)" to aria-label for screen readers |
  *
  * For a separator: `{ type: "separator" }`
  *

--- a/src/components/dropdown-menu/dropdown.stories.tsx
+++ b/src/components/dropdown-menu/dropdown.stories.tsx
@@ -458,6 +458,49 @@ export const WithoutIcons: Story = {
   },
 };
 
+const optionsWithExternalLinks: DropdownMenuItem[] = [
+  {
+    icon: <span className="material-icons">menu_book</span>,
+    label: "Documentation",
+    opensInNewWindow: true,
+    callback: () => alert("Open documentation"),
+  },
+  {
+    icon: <span className="material-icons">gavel</span>,
+    label: "Legal notice",
+    opensInNewWindow: true,
+    callback: () => alert("Open legal notice"),
+  },
+  { type: "separator" },
+  {
+    icon: <span className="material-icons">settings</span>,
+    label: "Settings",
+    callback: () => alert("Open settings"),
+  },
+];
+
+/**
+ * External links announce "(new window)" to screen readers via `aria-label`,
+ * without changing the visible label. Inspect `aria-label` in DevTools to verify.
+ */
+export const OpensInNewWindow: Story = {
+  args: {
+    options: optionsWithExternalLinks,
+  },
+  render: (args) => {
+    const { isOpen, setIsOpen } = useDropdownMenu();
+    return (
+      <DropdownMenu
+        options={args.options}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        <Button onClick={() => setIsOpen(!isOpen)}>Help</Button>
+      </DropdownMenu>
+    );
+  },
+};
+
 export const WithTopMessage: Story = {
   args: {
     options: [

--- a/src/components/dropdown-menu/types.ts
+++ b/src/components/dropdown-menu/types.ts
@@ -1,9 +1,8 @@
 import { MenuItemAction, MenuItemSeparator } from "../menu/types";
 
 /**
- * DropdownMenu option extending the shared MenuItemAction
- * Adds selection-specific props: isChecked, value
- * @deprecated showSeparator - use MenuItemSeparator instead
+ * DropdownMenu option extending the shared MenuItemAction.
+ * Adds selection-specific props: isChecked, value.
  */
 export type DropdownMenuOption = MenuItemAction & {
   isChecked?: boolean;

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -15,6 +15,7 @@ export type MenuItemAction = {
   keepOpen?: boolean;
   testId?: string;
   children?: MenuItem[];
+  opensInNewWindow?: boolean;
 };
 
 /**

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "menu": {
+      "newWindowLabelSuffix": " (neues Fenster)"
+    },
     "share": {
       "copyLink": "Link kopieren",
       "ok": "OK",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "menu": {
+      "newWindowLabelSuffix": " (new window)"
+    },
     "share": {
       "copyLink": "Copy link",
       "ok": "OK",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "menu": {
+      "newWindowLabelSuffix": " (nueva ventana)"
+    },
     "share": {
       "copyLink": "Copiar enlace",
       "ok": "OK",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "menu": {
+      "newWindowLabelSuffix": " (nouvelle fenêtre)"
+    },
     "share": {
       "copyLink": "Copier le lien",
       "ok": "OK",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "menu": {
+      "newWindowLabelSuffix": " (nieuw venster)"
+    },
     "share": {
       "copyLink": "Link kopiëren",
       "ok": "OK",


### PR DESCRIPTION
## Purpose

Improve dropdown and context menu accessibility for screen readers when items open external links
When a menu item opens a link in a new page or tab, screen readers must announce it:

- announce “(new window)” without changing the visible menu label (DSFR / RGAA pattern)
- keep `label` as the only visible text for menu items
- provide an i18n-backed `aria-label` suffix for supported UI Kit locales

## Proposal

- Add opensInNewWindow?: boolean on MenuItemAction
- Append an i18n suffix to aria-label when enabled
- Add components.menu.newWindowLabelSuffix in en-US, fr-FR, nl-NL, de-DE, es-ES

Dom example : 

<img width="1201" height="486" alt="label sr" src="https://github.com/user-attachments/assets/aaf46853-4c67-47da-a7fc-b99df7b75fa4" />

## Usage (Docs)

```tsx
{
  label: t('Documentation'),
  opensInNewWindow: true,
  callback: () => openExternalLink(documentationUrl),
}