### PR TITLE
Fix/modal

### DIFF
--- a/e2e/file-preview/pdf-preview-mixed-sizes.spec.tsx
+++ b/e2e/file-preview/pdf-preview-mixed-sizes.spec.tsx
@@ -147,6 +147,7 @@ test.describe("PDF Preview — mixed page sizes", () => {
       await expect(pageInput).toHaveAttribute(
         "size",
         String(String(target).length),
+        { timeout: 10000 },
       );
       await pageInput.press("Enter");
       await expect(getRenderedPage(page, target)).toBeVisible({

--- a/src/components/modal/index.scss
+++ b/src/components/modal/index.scss
@@ -14,6 +14,10 @@
   box-shadow: none;
 }
 
+.c__modal__scroller {
+  padding: var(--c--globals--spacings--md) !important;
+}
+
 .c__modal__close button {
   padding: 0;
   font-size: 88px;

--- a/src/components/modal/index.scss
+++ b/src/components/modal/index.scss
@@ -50,4 +50,10 @@
     gap: 0.5rem;
     flex-direction: column-reverse;
   }
+
+  .c__modal__footer {
+    button {
+      justify-content: center;
+    }
+  }
 }


### PR DESCRIPTION
* Center modal buttons on mobile (see [figma](https://www.figma.com/design/7CEGGvKD9zbqI3U6vkFtqu/Transcripts?node-id=7060-12039&t=QU0s9EZJPLAniaKu-0))
* Fixes an issue with modal behaving badly on small screen sizes (horizontal scroll and close button being off). Not 100% sure about that commit, if we should make the fix elsewhere instead. At least it is less broken, we might want a better fix later.