### PR TITLE
🐛(frontend) fix search-modal issues

### DIFF
--- a/src/components/quick-search/QuickSearchItemTemplate.tsx
+++ b/src/components/quick-search/QuickSearchItemTemplate.tsx
@@ -20,7 +20,7 @@ export const QuickSearchItemTemplate = ({
     <div className="c__quick-search-item-template" data-testid={testId}>
       <div className="c__quick-search-item-template__left">{left}</div>
 
-      {isDesktop && right && (
+      {(isDesktop || alwaysShowRight) && right && (
         <div
           className={clsx("c__quick-search-item-template__right", {
             "always-show-right": alwaysShowRight,

--- a/src/components/quick-search/index.scss
+++ b/src/components/quick-search/index.scss
@@ -9,11 +9,16 @@
     color: var(--c--contextuals--content--semantic--neutral--tertiary);
   }
 
-  .quick-search-input {
+  input.quick-search-input {
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--c--contextuals--content--semantic--neutral--primary);
+
     &::placeholder {
       color: var(
         --c--contextuals--content--semantic--neutral--tertiary
-      ) !important;
+      );
     }
   }
 }


### PR DESCRIPTION
QuickSearchItem takes an `alwaysShowRight` prop but this right container was only gated to `isDesktop` so on small viewports, no matter the value of `alwaysShowRight` items were hidden.

Then we also fix a little style issue with dark theme, the quick search input had the default browser background.

| Before | After |
|--|--|
|<img width="600" alt="Capture d’écran 2026-06-16 à 08 53 22" src="https://github.com/user-attachments/assets/c6eba214-91b7-4201-82ad-1ecb01230ed9" />|<img width="600" alt="Capture d’écran 2026-06-16 à 08 53 33" src="https://github.com/user-attachments/assets/95f51aa8-9026-4774-81b4-f947985deb3b" />|