### PR TITLE
🚸(LaGaufreV2) automatic positionning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor Changes
 
 - ♿️(menu) add opensInNewWindow for external link aria-label #246
+- 🚸(LaGaufreV2) automatic positionning #260
 
 ## 0.23.2
 

--- a/e2e/helpers/mount-la-gaufre.tsx
+++ b/e2e/helpers/mount-la-gaufre.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { CunninghamProvider } from "../../src/components/Provider/Provider";
+import {
+  LaGaufreV2,
+  LaGaufreV2Props,
+} from "../../src/components/la-gaufre/LaGaufreV2";
+
+export type ButtonViewportPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+const viewportStyles: Record<ButtonViewportPosition, React.CSSProperties> = {
+  "top-left": { position: "fixed", top: 10, left: 10 },
+  "top-right": { position: "fixed", top: 10, right: 10 },
+  "bottom-left": { position: "fixed", bottom: 10, left: 10 },
+  "bottom-right": { position: "fixed", bottom: 10, right: 10 },
+};
+
+export type TestLaGaufreV2Props = LaGaufreV2Props & {
+  buttonViewportPosition?: ButtonViewportPosition;
+};
+
+export const TestLaGaufreV2 = ({
+  buttonViewportPosition,
+  ...props
+}: TestLaGaufreV2Props) => {
+  const wrapperStyle = buttonViewportPosition
+    ? viewportStyles[buttonViewportPosition]
+    : undefined;
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <div style={wrapperStyle}>
+        <LaGaufreV2 {...props} />
+      </div>
+    </CunninghamProvider>
+  );
+};

--- a/e2e/la-gaufre/la-gaufre-v2.spec.tsx
+++ b/e2e/la-gaufre/la-gaufre-v2.spec.tsx
@@ -1,0 +1,229 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import type { Page } from "@playwright/test";
+import { TestLaGaufreV2 } from "../helpers/mount-la-gaufre";
+import type { Service } from "../../src/components/la-gaufre/LaGaufreV2";
+
+// A 1×1 transparent GIF avoids external logo requests while satisfying
+// the widget's logo guard (services without a logo are silently skipped).
+const LOGO =
+  "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+
+const mockServices: Service[] = [
+  { name: "Tchap", url: "https://tchap.gouv.fr", logo: LOGO },
+  { name: "Webinaire", url: "https://webinaire.numerique.gouv.fr", logo: LOGO },
+  { name: "Resana", url: "https://resana.numerique.gouv.fr", logo: LOGO },
+];
+
+const shadowHost = () => "#lasuite-widget-lagaufre-shadow";
+
+test.use({ viewport: { width: 1280, height: 720 } });
+
+// ---------------------------------------------------------------------------
+// Button
+// ---------------------------------------------------------------------------
+test.describe("LaGaufreV2 — button", () => {
+  test("renders an accessible waffle button with an aria-label", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2
+        data={{ services: mockServices }}
+        label="Open suite apps"
+      />
+    );
+
+    const button = page.locator("button.lagaufre-button");
+    await expect(button).toBeVisible();
+    await expect(button).toHaveAttribute("aria-label", "Open suite apps");
+    await expect(button.locator("svg")).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Panel interaction
+// ---------------------------------------------------------------------------
+test.describe("LaGaufreV2 — panel interaction", () => {
+  test("clicking the button opens the widget panel and lists services", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2 data={{ services: mockServices }} />
+    );
+
+    // Wait for the real widget to inject its shadow host.
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+
+    await page.locator("button.lagaufre-button").click();
+
+    // The panel (#wrapper inside the shadow root) becomes visible.
+    const panel = page.locator(`${shadowHost()} #wrapper`);
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    // Every service card has a .service-name element with the service name.
+    const names = page.locator(`${shadowHost()} .service-name`);
+    await expect(names).toHaveCount(mockServices.length, { timeout: 5_000 });
+    await expect(names.nth(0)).toHaveText("Tchap");
+    await expect(names.nth(1)).toHaveText("Webinaire");
+    await expect(names.nth(2)).toHaveText("Resana");
+  });
+
+  test("clicking the button again closes the panel (toggle)", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2 data={{ services: mockServices }} />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+
+    const button = page.locator("button.lagaufre-button");
+    const panel = page.locator(`${shadowHost()} #wrapper`);
+
+    // Open
+    await button.click();
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    await expect(button).toHaveAttribute("aria-expanded", "true");
+    await page.waitForTimeout(250);
+
+    // Close
+    await button.click();
+    await expect(panel).toBeHidden({ timeout: 5_000 });
+  });
+
+  test("each service card is a link pointing to the service URL", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2 data={{ services: mockServices }} />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+    await page.locator("button.lagaufre-button").click();
+
+    const tchapLink = page.locator(
+      `${shadowHost()} a[href="https://tchap.gouv.fr"]`
+    );
+    await expect(tchapLink).toBeVisible({ timeout: 5_000 });
+    // All service links open in a new tab.
+    await expect(tchapLink).toHaveAttribute("target", "_blank");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Panel positioning
+// ---------------------------------------------------------------------------
+test.describe("LaGaufreV2 — panel positioning", () => {
+  /**
+   * Returns the inline style values set on #wrapper (the positioned panel
+   * element inside the shadow root). The real widget uses "unset" for sides
+   * that are not active, so we compare against that.
+   */
+  async function getPanelSides(page: Page) {
+    return page.locator(`${shadowHost()} #wrapper`).evaluate((el: HTMLElement) => {
+      const s = (el as HTMLElement).style;
+      return { top: s.top, bottom: s.bottom, left: s.left, right: s.right };
+    });
+  }
+
+  test("panel opens below the button when the button is in the top half of the viewport", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2
+        data={{ services: mockServices }}
+        buttonViewportPosition="top-right"
+      />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+    await page.locator("button.lagaufre-button").click();
+    await expect(
+      page.locator(`${shadowHost()} #wrapper`)
+    ).toBeVisible({ timeout: 5_000 });
+
+    const { top, bottom } = await getPanelSides(page);
+
+    // position() sets top=<px> and bottom="unset" for top-half buttons.
+    expect(top).toMatch(/^\d+(\.\d+)?px$/);
+    expect(bottom).toBe("unset");
+
+    // The panel top value must be greater than the button's bottom edge.
+    const buttonBox = await page
+      .locator("button.lagaufre-button")
+      .boundingBox();
+    expect(parseFloat(top)).toBeGreaterThan(buttonBox!.y);
+  });
+
+  test("panel opens above the button when the button is in the bottom half of the viewport", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2
+        data={{ services: mockServices }}
+        buttonViewportPosition="bottom-right"
+      />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+    await page.locator("button.lagaufre-button").click();
+    await expect(
+      page.locator(`${shadowHost()} #wrapper`)
+    ).toBeVisible({ timeout: 5_000 });
+
+    const { top, bottom } = await getPanelSides(page);
+
+    // position() sets bottom=<px> and top="unset" for bottom-half buttons.
+    expect(bottom).toMatch(/^\d+(\.\d+)?px$/);
+    expect(top).toBe("unset");
+  });
+
+  test("panel aligns to the right edge when the button is on the right side", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2
+        data={{ services: mockServices }}
+        buttonViewportPosition="top-right"
+      />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+    await page.locator("button.lagaufre-button").click();
+    await expect(
+      page.locator(`${shadowHost()} #wrapper`)
+    ).toBeVisible({ timeout: 5_000 });
+
+    const { right, left } = await getPanelSides(page);
+    expect(right).toMatch(/^\d+(\.\d+)?px$/);
+    expect(left).toBe("unset");
+  });
+
+  test("panel aligns to the left edge when the button is on the left side", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestLaGaufreV2
+        data={{ services: mockServices }}
+        buttonViewportPosition="top-left"
+      />
+    );
+
+    await expect(page.locator(shadowHost())).toBeAttached({ timeout: 10_000 });
+    await page.locator("button.lagaufre-button").click();
+    await expect(
+      page.locator(`${shadowHost()} #wrapper`)
+    ).toBeVisible({ timeout: 5_000 });
+
+    const { right, left } = await getPanelSides(page);
+    expect(left).toMatch(/^\d+(\.\d+)?px$/);
+    expect(right).toBe("unset");
+  });
+});

--- a/src/components/la-gaufre/LaGaufreV2.stories.tsx
+++ b/src/components/la-gaufre/LaGaufreV2.stories.tsx
@@ -30,3 +30,26 @@ export const Default: Story = {
     );
   },
 };
+
+export const BottomLeft: Story = {
+  args: {
+    widgetPath: "https://static.suite.anct.gouv.fr/widgets/lagaufre.js",
+    apiUrl: "https://lasuite.numerique.gouv.fr/api/services",
+  },
+  render: (args) => {
+    return (
+      <div
+        style={{
+          width: "80vw",
+          height: "80vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "flex-start",
+          padding: "30px",
+        }}
+      >
+        <LaGaufreV2 {...args} />
+      </div>
+    );
+  },
+};

--- a/src/components/la-gaufre/LaGaufreV2.tsx
+++ b/src/components/la-gaufre/LaGaufreV2.tsx
@@ -112,17 +112,35 @@ export const LaGaufreV2 = memo(
           viewLessLabel: viewLessLabel,
           buttonElement: buttonRef.current,
           position: () => {
-            return {
-              position: "absolute",
-              top:
-                (buttonRef.current?.offsetTop ?? 0) +
-                (buttonRef.current?.offsetHeight ?? 0) +
-                10,
-              right:
-                window.innerWidth -
-                (buttonRef.current?.offsetLeft ?? 0) -
-                (buttonRef.current?.offsetWidth ?? 0),
+            const button = buttonRef.current;
+            if (!button) return { position: "absolute", top: 10, right: 10 };
+
+            const rect = button.getBoundingClientRect();
+            const gap = 10;
+
+            const result: Record<string, number | string> = {
+              position: "fixed",
             };
+
+            /**
+             * The widget creates the shadow host after calling position(), so we can never measure it here.
+             * Button is in the lower half of the viewport — place panel above. 
+            */
+            if (rect.top > window.innerHeight / 2) {
+              result.bottom = window.innerHeight - rect.top + gap;
+            } else {
+              result.top = rect.bottom + gap;
+            }
+
+            // Source: https://github.com/suitenumerique/integration/blob/5316093a071ddc6cf348994d9bdc30b5fdc256d8/packages/widgets/src/widgets/lagaufre/styles.css#L13
+            const panelWidth = 340;
+            if (rect.right >= panelWidth) {
+              result.right = window.innerWidth - rect.right;
+            } else {
+              result.left = rect.left;
+            }
+
+            return result;
           },
         },
       ]);


### PR DESCRIPTION
## Purpose

La Gauffre can be positioned to the bottom left of the page (on new Docs design).
<img width="222" height="132" alt="image" src="https://github.com/user-attachments/assets/a7bc8066-defe-4aaf-9bc6-e698460afd9c" />

As it is now, the LaGaufreV2 component is positioned only in the bottom left corner of the trigger button, so the floating container can be out of the viewport:
<img width="482" height="397" alt="image" src="https://github.com/user-attachments/assets/f64d6ef1-0ae9-4269-8156-a25fbb587118" />


Now, depend on the position of the trigger button, the component will be positioned in the best place possible, to avoid being cut off by the viewport.

We added a story to show the behavior, plus e2e tests to check the component.

## Demo

<img width="752" height="375" alt="image" src="https://github.com/user-attachments/assets/9b0bd914-1904-41f4-89ff-7eb759e3f1fd" />

----

Related to https://github.com/suitenumerique/docs/pull/2455
