### PR TITLE
✨(filters) add subContent in options

### DIFF
--- a/e2e/filter/filter.spec.tsx
+++ b/e2e/filter/filter.spec.tsx
@@ -1,0 +1,175 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TestFilter } from "../helpers/mount-filter";
+
+test.describe("Filter", () => {
+  test.beforeEach(async ({ mount, page }) => {
+    await mount(<TestFilter />);
+    await expect(page.getByRole("button", { name: /Updated/ })).toBeVisible();
+  });
+
+  // --- Core Filter behavior -------------------------------------------------
+
+  test("opens the dropdown and shows all options", async ({ page }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    await expect(page.getByRole("listbox")).toBeVisible();
+    for (const name of ["Today", "Yesterday", "Last week", "Custom"]) {
+      await expect(page.getByRole("option", { name })).toBeVisible();
+    }
+  });
+
+  test("selecting a normal option closes the dropdown and updates the button", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    await page.getByRole("option", { name: "Today" }).click();
+
+    await expect(page.getByRole("listbox")).not.toBeVisible();
+    await expect(trigger).toHaveAccessibleName("Updated : Today");
+  });
+
+  test("shows a checkmark on the selected option", async ({ page }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    // Nothing selected yet → no checkmark anywhere.
+    await expect(page.getByText("check", { exact: true })).toHaveCount(0);
+
+    await page.getByRole("option", { name: "Today" }).click();
+
+    // Reopen: the selected option is marked and renders the checkmark icon.
+    await trigger.click();
+    const selected = page.getByRole("option", { name: "Today", selected: true });
+    await expect(selected).toBeVisible();
+    await expect(selected.getByText("check", { exact: true })).toBeVisible();
+
+    // The checkmark is exclusive to the selected option.
+    await expect(page.getByText("check", { exact: true })).toHaveCount(1);
+  });
+
+  test("the Custom option shows a chevron affordance that normal options lack", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    await expect(
+      page.getByRole("option", { name: "Custom" }),
+    ).toHaveAccessibleName(/chevron_right/);
+    await expect(
+      page.getByRole("option", { name: "Today" }),
+    ).toHaveAccessibleName("Today");
+  });
+
+  // --- Sub-element (CalendarRange) feature -----------------------------------
+
+  test("hovering the Custom row opens the calendar sub-panel", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+
+    await expect(page.getByRole("grid")).toBeVisible();
+  });
+
+  test("opens the sub-panel with the keyboard and restores focus on Escape", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.focus();
+    await page.keyboard.press("Enter"); // open the dropdown
+    await expect(page.getByRole("listbox")).toBeVisible();
+
+    // Move focus down to the Custom row, then open its sub-panel with Enter.
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press("ArrowDown");
+    }
+    await page.keyboard.press("Enter");
+
+    // Sub-panel opens, the dropdown stays open, and focus moves into the panel.
+    const grid = page.getByRole("grid");
+    await expect(grid).toBeVisible();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    const focusInPanel = await page.evaluate(
+      () => !!document.activeElement?.closest(".c__filter__subpanel"),
+    );
+    expect(focusInPanel).toBe(true);
+
+    // Escape closes the panel and returns focus to the Custom row.
+    await page.keyboard.press("Escape");
+    await expect(grid).not.toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Custom" }),
+    ).toBeFocused();
+  });
+
+  test("clicking the Custom row is ignored and keeps the dropdown open", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    const customOption = page.getByRole("option", { name: "Custom" });
+    // Click the left edge (padding/label) and the center to cover the row
+    // padding vs the inner element: the press must be swallowed in either case.
+    await customOption.click({ position: { x: 6, y: 12 } });
+    await expect(page.getByRole("listbox")).toBeVisible();
+
+    await customOption.click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+  });
+
+  test("confirming a range selects Custom and shows the range in the button", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+
+    // Only selectable days have a button child inside the grid.
+    const days = page.getByRole("grid").getByRole("button");
+    await days.nth(8).click();
+    await days.nth(12).click();
+
+    await page.getByRole("button", { name: "OK" }).click();
+
+    await expect(page.getByRole("listbox")).not.toBeVisible();
+    await expect(trigger).toHaveAccessibleName(
+      /Updated : \d{4}-\d{2}-\d{2} – \d{4}-\d{2}-\d{2}/,
+    );
+  });
+
+  test("Cancel closes the sub-panel without selecting", async ({ page }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(page.getByRole("grid")).not.toBeVisible();
+    await expect(trigger).toHaveAccessibleName("Updated");
+  });
+
+  test("Reset clears a confirmed range", async ({ page }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+    const days = page.getByRole("grid").getByRole("button");
+    await days.nth(8).click();
+    await days.nth(12).click();
+    await page.getByRole("button", { name: "OK" }).click();
+
+    await expect(trigger).toHaveAccessibleName(/Updated : /);
+
+    await page.getByRole("button", { name: "Reset" }).click();
+
+    await expect(trigger).toHaveAccessibleName("Updated");
+  });
+});

--- a/e2e/helpers/mount-filter.tsx
+++ b/e2e/helpers/mount-filter.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Key } from "react-aria-components";
+import { Button, CalendarRange } from "@gouvfr-lasuite/cunningham-react";
+import { DateValue } from "@internationalized/date";
+import { CunninghamProvider } from "../../src/components/Provider/Provider";
+import { Filter, FilterOption } from "../../src/components/filter/Filter";
+
+// Playwright CT bridges function props as one-way dispatchers whose return
+// value is always `undefined`, so render props (`subContent`) can't be passed
+// from the test file. This helper runs in the browser and builds the actual
+// stateful scenario locally, mirroring the `UpdatedWithDateRange` story.
+
+type DateRangeValue = { start: DateValue; end: DateValue };
+
+const formatRange = (range: DateRangeValue) =>
+  `${range.start.toString()} – ${range.end.toString()}`;
+
+export const TestFilter = () => {
+  const [selected, setSelected] = useState<Key | null>(null);
+  const [range, setRange] = useState<DateRangeValue | null>(null);
+
+  const reset = () => {
+    setSelected(null);
+    setRange(null);
+  };
+
+  const options: FilterOption[] = [
+    { label: "Today", value: "today" },
+    { label: "Yesterday", value: "yesterday" },
+    { label: "Last week", value: "lastWeek", showSeparator: true },
+    {
+      label: range ? formatRange(range) : "Custom",
+      value: "custom",
+      subContent: ({ select, close }) => (
+        <CalendarRange
+          value={range}
+          onChange={setRange}
+          onOk={() => {
+            select();
+            close();
+          }}
+          onCancel={close}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <div style={{ display: "flex", gap: "1em", alignItems: "center" }}>
+        <Filter
+          label="Updated"
+          options={options}
+          value={selected}
+          onChange={setSelected}
+        />
+        <Button size="small" onClick={reset}>
+          Reset
+        </Button>
+      </div>
+    </CunninghamProvider>
+  );
+};

--- a/src/components/context-menu/ContextMenuProvider.tsx
+++ b/src/components/context-menu/ContextMenuProvider.tsx
@@ -15,6 +15,7 @@ import {
   MenuItemAction,
   ContextMenuState,
 } from "./types";
+import { MenuItemBody } from "../menu/MenuItemBody";
 import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 const ContextMenuContext = createContext<ContextMenuContextValue | null>(null);
@@ -193,17 +194,11 @@ export const ContextMenuProvider = ({ children }: PropsWithChildren) => {
                 isDisabled={item.isDisabled}
                 data-testid={item.testId || `context-menu-item-${itemKey}`}
               >
-                {item.icon}
-                <div className="c__dropdown-menu-item__label-container">
-                  <div className="c__dropdown-menu-item__label">
-                    {item.label}
-                  </div>
-                  {item.subText && (
-                    <div className="c__dropdown-menu-item__label-subtext">
-                      {item.subText}
-                    </div>
-                  )}
-                </div>
+                <MenuItemBody
+                  icon={item.icon}
+                  label={item.label}
+                  subText={item.subText}
+                />
               </AriaMenuItem>
             );
           })}

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -7,6 +7,7 @@ import {
   SubmenuTrigger,
 } from "react-aria-components";
 import { MenuItemAction, MenuItemSeparator } from "../menu/types";
+import { MenuItemBody } from "../menu/MenuItemBody";
 import { DropdownMenuItem } from "./types";
 import { Fragment, PropsWithChildren, ReactNode, useId, useRef } from "react";
 import clsx from "clsx";
@@ -19,22 +20,6 @@ const isSeparator = (item: DropdownMenuItem): item is MenuItemSeparator => {
 const hasChildren = (item: MenuItemAction): boolean => {
   return Array.isArray(item.children) && item.children.length > 0;
 };
-
-const MenuItemContent = ({ option }: { option: MenuItemAction }) => (
-  <>
-    {option.icon && (
-      <div className="c__dropdown-menu-item__icon">{option.icon}</div>
-    )}
-    <div className="c__dropdown-menu-item__label-container">
-      <div className="c__dropdown-menu-item__label">{option.label}</div>
-      {option.subText && (
-        <div className="c__dropdown-menu-item__label-subtext">
-          {option.subText}
-        </div>
-      )}
-    </div>
-  </>
-);
 
 export type DropdownMenuProps = {
   options: DropdownMenuItem[];
@@ -98,10 +83,12 @@ export const DropdownMenu = ({
               isDisabled={option.isDisabled}
               data-testid={option.testId}
             >
-              <MenuItemContent option={option} />
-              <span className="material-icons c__dropdown-menu-item__chevron">
-                chevron_right
-              </span>
+              <MenuItemBody
+                icon={option.icon}
+                label={option.label}
+                subText={option.subText}
+                hasSubmenu
+              />
             </MenuItem>
             <Popover offset={-4} shouldFlip containerPadding={16}>
               <Menu className={menuClassName}>
@@ -131,11 +118,15 @@ export const DropdownMenu = ({
             isDisabled={option.isDisabled}
             data-testid={option.testId}
           >
-            <MenuItemContent option={option} />
-            {(option.isChecked ||
-              (option.value && selectedValues.includes(option.value))) && (
-              <span className="material-icons checked">check</span>
-            )}
+            <MenuItemBody
+              icon={option.icon}
+              label={option.label}
+              subText={option.subText}
+              isChecked={
+                option.isChecked ||
+                (!!option.value && selectedValues.includes(option.value))
+              }
+            />
           </MenuItem>
           {/* @deprecated: use { type: "separator" } instead */}
           {option.showSeparator && <Separator />}

--- a/src/components/filter/Filter.stories.tsx
+++ b/src/components/filter/Filter.stories.tsx
@@ -3,14 +3,99 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Filter, FilterOption } from "./Filter";
 import { useState } from "react";
 import { Key } from "react-aria-components";
-import { Button } from "@gouvfr-lasuite/cunningham-react";
+import { Button, CalendarRange } from "@gouvfr-lasuite/cunningham-react";
+import { DateValue } from "@internationalized/date";
 
+/**
+ * The `Filter` component is a single-select dropdown built on react-aria's
+ * `Select`. It renders a labelled trigger button that reflects the current
+ * selection (`label : value`) and opens a list of options in a popover. It is
+ * meant for the inline, toolbar-style filters you place above a list or table.
+ *
+ * Highlights:
+ *
+ * - **Controlled or uncontrolled.** Use `defaultValue` to let the
+ *   component own its state, or `value` + `onChange` to drive it
+ *   from your own state.
+ * - **Custom option rendering.** Each option can supply a `render` function to
+ *   display icons or richer content instead of a plain label.
+ * - **Separators.** Set `showSeparator` on an option to draw a divider after it.
+ * - **Sub-panels.** An option can expose a `subContent` panel (e.g. a date-range
+ *   picker) that opens on hover, with `select` / `close` helpers to drive the
+ *   parent selection.
+ *
+ * ## Basic usage
+ *
+ * ```tsx
+ * import { Filter, FilterOption } from "@gouvfr-lasuite/ui-kit";
+ *
+ * const options: FilterOption[] = [
+ *   { label: "All", value: "all" },
+ *   { label: "File", value: "file" },
+ *   { label: "Folder", value: "folder" },
+ * ];
+ *
+ * export const MyFilter = () => (
+ *   <Filter label="Type" options={options} defaultValue="file" />
+ * );
+ * ```
+ *
+ * ## `FilterProps`
+ *
+ * `FilterProps` extends react-aria's `SelectProps`, so every selection-related
+ * prop (`value`, `defaultValue`, `onChange`,
+ * `isDisabled`, …) is available in addition to the props below.
+ *
+ * | Prop | Type | Description |
+ * |------|------|-------------|
+ * | `label` | `string` | Text shown on the trigger button; combined with the selected option's label once a value is picked |
+ * | `options` | `FilterOption[]` | The selectable entries |
+ * | `defaultValue` | `Key \| null?` | Initial selection in uncontrolled mode |
+ * | `value` | `Key \| null?` | Selected value in controlled mode |
+ * | `onChange` | `(key: Key \| null) => void` | Fires when the user picks an option |
+ *
+ * ## `FilterOption`
+ *
+ * `FilterOption` extends Cunningham's `Option` (`label`, `value`, `render`, …).
+ *
+ * | Property | Type | Description |
+ * |----------|------|-------------|
+ * | `label` | `string` | Text shown in the row and in the trigger when selected |
+ * | `value` | `string` | Stable key used for selection |
+ * | `render` | `() => ReactNode` | Custom row content (e.g. an icon + label) |
+ * | `showSeparator` | `boolean?` | Draw a divider after this option |
+ * | `isChecked` | `boolean?` | Force the checkmark on this row |
+ * | `subContent` | `(helpers) => ReactNode` | Render a hover sub-panel; `helpers` exposes `select()` and `close()` |
+ */
 const meta: Meta<typeof Filter> = {
   title: "Components/Filter",
   component: Filter,
   tags: ["autodocs"],
   parameters: {
     layout: "fullscreen",
+  },
+  argTypes: {
+    label: {
+      description:
+        "Text shown on the trigger button; combined with the selected option's label once a value is picked",
+      control: "text",
+    },
+    options: {
+      description: "The selectable entries",
+      control: false,
+    },
+    defaultValue: {
+      description: "Initial selection in uncontrolled mode",
+      control: "text",
+    },
+    value: {
+      description: "Selected value in controlled mode",
+      control: false,
+    },
+    onChange: {
+      description: "Fires when the user picks an option",
+      control: false,
+    },
   },
   decorators: [
     (Story) => (
@@ -72,6 +157,11 @@ const OPTIONS_CUSTOM: FilterOption[] = [
   },
 ];
 
+/**
+ * The simplest setup: the component manages its own selection state. Nothing is
+ * selected on first render, so the trigger shows just the `label`. Picking an
+ * option updates the button to read `Type : <option>`.
+ */
 export const Uncontrolled: Story = {
   args: {
     label: "Type",
@@ -79,10 +169,15 @@ export const Uncontrolled: Story = {
   },
 };
 
+/**
+ * Same uncontrolled behaviour, but `defaultValue` pre-selects an option on
+ * mount. The trigger renders in its active state and the matching row shows a
+ * checkmark from the start.
+ */
 export const UncontrolledWithDefault: Story = {
   args: {
     label: "Type",
-    defaultSelectedKey: "folder",
+    defaultValue: "folder",
     options: OPTIONS,
   },
 };
@@ -102,6 +197,11 @@ const OPTIONS_LONG: FilterOption[] = [
   },
 ];
 
+/**
+ * Demonstrates how the component copes with long text in both the trigger label
+ * and the option rows. Labels wrap / truncate gracefully so the filter stays
+ * usable even with verbose content.
+ */
 export const LongLabels: Story = {
   args: {
     label: "Type de contenu à afficher dans la liste",
@@ -109,6 +209,12 @@ export const LongLabels: Story = {
   },
 };
 
+/**
+ * Several filters laid out side by side in a width-constrained, horizontally
+ * scrollable toolbar — the typical "filter bar" above a list. Shows that the
+ * triggers keep their sizing and the popovers position correctly in a cramped
+ * layout.
+ */
 export const MultipleInConstrainedContainer: Story = {
   render: () => (
     <div
@@ -124,7 +230,7 @@ export const MultipleInConstrainedContainer: Story = {
     >
       <Filter
         label="Type de contenu à afficher"
-        defaultSelectedKey="folder"
+        defaultValue="folder"
         options={[
           { label: "Dossier partagé avec l'équipe", value: "folder" },
           { label: "Fichier récemment modifié", value: "file" },
@@ -132,7 +238,7 @@ export const MultipleInConstrainedContainer: Story = {
       />
       <Filter
         label="Espace de travail collaboratif"
-        defaultSelectedKey="public"
+        defaultValue="public"
         options={[
           { label: "Espace public accessible à tous", value: "public" },
           { label: "Espace privé réservé aux membres", value: "private" },
@@ -140,7 +246,7 @@ export const MultipleInConstrainedContainer: Story = {
       />
       <Filter
         label="Emplacement du document dans l'arborescence"
-        defaultSelectedKey="trash"
+        defaultValue="trash"
         options={[
           { label: "Corbeille des éléments supprimés", value: "trash" },
           { label: "Favoris marqués par l'utilisateur", value: "favorites" },
@@ -151,6 +257,13 @@ export const MultipleInConstrainedContainer: Story = {
   ),
 };
 
+/**
+ * Controlled mode: the parent owns the selection via `value` +
+ * `onChange`. This example also uses `OPTIONS_CUSTOM`, so each row is
+ * drawn with a `render` function (icon + label), and treats the "All" option as
+ * a reset by clearing the selection. The Reset / Random buttons show that the
+ * trigger always reflects the externally-driven state.
+ */
 export const Controlled: Story = {
   args: {
     label: "Type",
@@ -163,8 +276,8 @@ export const Controlled: Story = {
       <div>
         <Filter
           {...args}
-          selectedKey={selected}
-          onSelectionChange={(key) => {
+          value={selected}
+          onChange={(key) => {
             if (key === "all") {
               setSelected(null);
             } else {
@@ -182,13 +295,81 @@ export const Controlled: Story = {
               setSelected(
                 OPTIONS_CUSTOM[
                   Math.floor(Math.random() * OPTIONS_CUSTOM.length)
-                ].value as Key
+                ].value as Key,
               )
             }
           >
             Random
           </Button>
         </div>
+      </div>
+    );
+  },
+};
+
+type DateRangeValue = { start: DateValue; end: DateValue };
+
+const formatRange = (range: DateRangeValue) =>
+  `${range.start.toString()} – ${range.end.toString()}`;
+
+/**
+ * A filter whose last option ("Custom") declares a `subContent` panel. The row
+ * renders with a chevron and, on hover, opens a sub-panel hosting a
+ * `CalendarRange` date picker.
+ *
+ * The `subContent` callback receives two helpers:
+ *
+ * - `select()` — sets the Filter's selected key to this option's value.
+ * - `close()` — closes the sub-panel and the Filter popover.
+ *
+ * Here, confirming the calendar (`onOk`) calls both to commit the range and
+ * dismiss the menu, while the option's `label` is rewritten to show the chosen
+ * range. Cancelling just closes the panel.
+ */
+export const UpdatedWithDateRange: Story = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selected, setSelected] = useState<Key | null>(null);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [range, setRange] = useState<DateRangeValue | null>(null);
+
+    const reset = () => {
+      setSelected(null);
+      setRange(null);
+    };
+
+    const options: FilterOption[] = [
+      { label: "Today", value: "today" },
+      { label: "Yesterday", value: "yesterday" },
+      { label: "Last week", value: "lastWeek", showSeparator: true },
+      {
+        label: range ? formatRange(range) : "Custom",
+        value: "custom",
+        subContent: ({ select, close }) => (
+          <CalendarRange
+            value={range}
+            onChange={setRange}
+            onOk={() => {
+              select();
+              close();
+            }}
+            onCancel={close}
+          />
+        ),
+      },
+    ];
+
+    return (
+      <div style={{ display: "flex", gap: "1em", alignItems: "center" }}>
+        <Filter
+          label="Updated"
+          options={options}
+          value={selected}
+          onChange={setSelected}
+        />
+        <Button size="small" onClick={reset}>
+          Reset
+        </Button>
       </div>
     );
   },

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -1,4 +1,13 @@
-import { Fragment, useContext } from "react";
+import {
+  createRef,
+  Fragment,
+  ReactNode,
+  RefObject,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import {
   Button,
   Label,
@@ -14,9 +23,21 @@ import {
 import { Option } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 
+export type FilterSubContentHelpers = {
+  /** Selects this option (sets the Filter's selected key to the option value). */
+  select: () => void;
+  /** Closes the sub-panel and the Filter popover. */
+  close: () => void;
+};
+
 export type FilterOption = Option & {
   showSeparator?: boolean;
   isChecked?: boolean;
+  /**
+   * Renders a custom sub-panel for this option. The row displays a chevron and,
+   * on hover, opens a panel hosting the returned content (e.g. a date-range picker).
+   */
+  subContent?: (helpers: FilterSubContentHelpers) => ReactNode;
 };
 
 export type FilterProps = {
@@ -24,19 +45,149 @@ export type FilterProps = {
   options: FilterOption[];
 } & SelectProps;
 
+/** Minimal slice of react-aria's SelectState used to drive custom selection. */
+type SelectStateLike = {
+  setValue: (value: string) => void;
+  close: () => void;
+};
+
+type RowRefMap = RefObject<Map<string, RefObject<HTMLDivElement | null>>>;
+
 export const Filter = (props: FilterProps) => {
+  // The sub-panel state lives here, in the stable parent, on purpose: react-aria
+  // renders the Select/ListBox children subtree twice (a hidden collection pass +
+  // the real pass), so any state held inside the Select would be split across two
+  // component instances and the hover updates would be lost. Keeping it in `Filter`
+  // — and rendering the sub-panel Popover *outside* the <Select> — sidesteps that.
+  const rowRefs: RowRefMap = useRef(
+    new Map<string, RefObject<HTMLDivElement | null>>(),
+  );
+  const getRowRef = (value: string) => {
+    if (!rowRefs.current.has(value)) {
+      rowRefs.current.set(value, createRef<HTMLDivElement>());
+    }
+    return rowRefs.current.get(value)!;
+  };
+
+  // Set from within the Select so the out-of-tree sub-panel can drive selection.
+  const selectStateRef = useRef<SelectStateLike | null>(null);
+
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [openKey, setOpenKey] = useState<string | null>(null);
+
+  // The content of the currently-open sub-panel, used to move focus into it when
+  // it is opened via the keyboard (`focusOnOpen`).
+  const panelRef = useRef<HTMLDivElement>(null);
+  const focusOnOpen = useRef(false);
+
+  const cancelClose = () => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+  };
+  const openSub = (value: string, withFocus = false) => {
+    cancelClose();
+    focusOnOpen.current = withFocus;
+    setOpenKey(value);
+  };
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimeout.current = setTimeout(() => setOpenKey(null), 150);
+  };
+
+  // When a sub-panel is opened via keyboard, move focus to its first focusable
+  // element so it is operable without a pointer.
+  useEffect(() => {
+    if (!openKey || !focusOnOpen.current) {
+      return;
+    }
+    focusOnOpen.current = false;
+    const focusable = panelRef.current?.querySelector<HTMLElement>(
+      'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    (focusable ?? panelRef.current)?.focus();
+  }, [openKey]);
+
+  const subOptions = props.options.filter(
+    (option) => option.subContent && option.value !== undefined,
+  );
+
   return (
-    <Select {...props} className="c__filter">
-      <FilterInner {...props} />
-    </Select>
+    <>
+      <Select {...props} className="c__filter">
+        <FilterInner
+          {...props}
+          getRowRef={getRowRef}
+          openSub={openSub}
+          scheduleClose={scheduleClose}
+          selectStateRef={selectStateRef}
+        />
+      </Select>
+
+      {subOptions.map((option) => {
+        const value = option.value as string;
+        const helpers: FilterSubContentHelpers = {
+          select: () => selectStateRef.current?.setValue(value),
+          close: () => {
+            cancelClose();
+            setOpenKey(null);
+            selectStateRef.current?.close();
+          },
+        };
+        return (
+          <Popover
+            key={value}
+            triggerRef={getRowRef(value)}
+            isOpen={openKey === value}
+            onOpenChange={(isOpen) => {
+              if (!isOpen) {
+                // Return focus to the row if the panel currently holds it (e.g.
+                // closed via Escape after being opened with the keyboard).
+                const restoreFocus = panelRef.current?.contains(
+                  document.activeElement,
+                );
+                setOpenKey(null);
+                if (restoreFocus) {
+                  getRowRef(value).current?.focus();
+                }
+              }
+            }}
+            isNonModal
+            placement="right top"
+            className="c__filter__subpanel"
+          >
+            <div
+              ref={openKey === value ? panelRef : undefined}
+              onMouseEnter={cancelClose}
+              onMouseLeave={scheduleClose}
+            >
+              {option.subContent?.(helpers)}
+            </div>
+          </Popover>
+        );
+      })}
+    </>
   );
 };
 
-const FilterInner = (props: FilterProps) => {
+type FilterInnerProps = FilterProps & {
+  getRowRef: (value: string) => RefObject<HTMLDivElement | null>;
+  openSub: (value: string, withFocus?: boolean) => void;
+  scheduleClose: () => void;
+  selectStateRef: RefObject<SelectStateLike | null>;
+};
+
+const FilterInner = (props: FilterInnerProps) => {
+  const { getRowRef, openSub, scheduleClose, selectStateRef, ...filterProps } =
+    props;
   const state = useContext(SelectStateContext);
 
-  const selectedOption = state?.selectedItem
-    ? props.options.find((option) => option.value === state.selectedItem?.key)
+  // Expose the Select state to the out-of-tree sub-panel (see Filter comment).
+  selectStateRef.current = state ?? null;
+
+  const selectedOption = state?.value
+    ? filterProps.options.find((option) => option.value === state.value)
     : null;
 
   return (
@@ -49,12 +200,12 @@ const FilterInner = (props: FilterProps) => {
         <Label className="c__filter__label">
           {selectedOption ? (
             <>
-              {props.label}
+              {filterProps.label}
               {" : "}
               {selectedOption.label}
             </>
           ) : (
-            <>{props.label}</>
+            <>{filterProps.label}</>
           )}
         </Label>
         <span
@@ -66,26 +217,106 @@ const FilterInner = (props: FilterProps) => {
           keyboard_arrow_down
         </span>
       </Button>
-      <Popover className="c__dropdown-menu">
-        <ListBox>
-          {props.options.map((option) => (
-            <Fragment key={option.value}>
-              <ListBoxItem
-                key={option.value}
-                id={option.value}
-                className="c__dropdown-menu-item"
-              >
-                <div className="c__filter__item">
-                  {option.render ? option.render() : option.label}
-                  {(props.selectedKey === option.value || option.isChecked) && (
-                    <span className="material-icons checked">check</span>
-                  )}
-                </div>
-              </ListBoxItem>
-              {option.showSeparator && <Separator />}
-            </Fragment>
-          ))}
-        </ListBox>
+      <Popover
+        className="c__dropdown-menu"
+        shouldCloseOnInteractOutside={(element) =>
+          !element.closest(".c__filter__subpanel")
+        }
+      >
+        {/*
+         * Keyboard equivalent of hover for sub-content rows. Handled here in the
+         * capture phase (ListBoxItem doesn't accept `onKeyDownCapture`) so it runs
+         * before react-aria's selection handler: Enter/Space/ArrowRight on a
+         * sub-content row opens its panel and moves focus into it instead of
+         * selecting the row.
+         */}
+        <div
+          onKeyDownCapture={(event) => {
+            if (
+              event.key !== "Enter" &&
+              event.key !== " " &&
+              event.key !== "ArrowRight"
+            ) {
+              return;
+            }
+            const row = (event.target as HTMLElement).closest<HTMLElement>(
+              "[data-submenu-value]",
+            );
+            const value = row?.dataset.submenuValue;
+            if (value) {
+              event.stopPropagation();
+              event.preventDefault();
+              openSub(value, true);
+            }
+          }}
+        >
+          <ListBox>
+          {filterProps.options.map((option) => {
+            const hasSubContent =
+              !!option.subContent && option.value !== undefined;
+            return (
+              <Fragment key={option.value}>
+                <ListBoxItem
+                  key={option.value}
+                  id={option.value}
+                  textValue={option.label}
+                  className="c__dropdown-menu-item"
+                  data-has-submenu={hasSubContent}
+                  // Carries the option value (the DOM `id` is a react-aria
+                  // generated key) so the keyboard handler can open this row.
+                  data-submenu-value={hasSubContent ? option.value : undefined}
+                  ref={hasSubContent ? getRowRef(option.value!) : undefined}
+                  onMouseEnter={
+                    hasSubContent
+                      ? () => openSub(option.value as string)
+                      : undefined
+                  }
+                  onMouseLeave={hasSubContent ? scheduleClose : undefined}
+                  // Swallow the press in the capture phase so react-aria's Select
+                  // never selects this row (which would close the popover). The
+                  // sub-panel is driven by hover + its own actions instead.
+                  onPointerDownCapture={
+                    hasSubContent
+                      ? (event) => event.stopPropagation()
+                      : undefined
+                  }
+                  onPointerUpCapture={
+                    hasSubContent
+                      ? (event) => event.stopPropagation()
+                      : undefined
+                  }
+                >
+                  {/*
+                   * Use the ListBoxItem render prop for selection: the checkmark
+                   * lives inside the ListBox collection, which react-aria renders
+                   * in a pass without `SelectStateContext`, so reading `state`
+                   * here is unreliable. `isSelected` is provided per item and is
+                   * correct in both controlled and uncontrolled modes.
+                   */}
+                  {({ isSelected }) =>
+                    hasSubContent ? (
+                      <div className="c__filter__item">
+                        {option.render ? option.render() : option.label}
+                        <span className="material-icons c__dropdown-menu-item__chevron">
+                          chevron_right
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="c__filter__item">
+                        {option.render ? option.render() : option.label}
+                        {(isSelected || option.isChecked) && (
+                          <span className="material-icons checked">check</span>
+                        )}
+                      </div>
+                    )
+                  }
+                </ListBoxItem>
+                {option.showSeparator && <Separator />}
+              </Fragment>
+            );
+          })}
+          </ListBox>
+        </div>
       </Popover>
     </>
   );

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -23,6 +23,8 @@ import {
 import { Option } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 
+import { MenuItemBody } from "../menu/MenuItemBody";
+
 export type FilterSubContentHelpers = {
   /** Selects this option (sets the Filter's selected key to the option value). */
   select: () => void;
@@ -293,23 +295,13 @@ const FilterInner = (props: FilterInnerProps) => {
                    * here is unreliable. `isSelected` is provided per item and is
                    * correct in both controlled and uncontrolled modes.
                    */}
-                  {({ isSelected }) =>
-                    hasSubContent ? (
-                      <div className="c__filter__item">
-                        {option.render ? option.render() : option.label}
-                        <span className="material-icons c__dropdown-menu-item__chevron">
-                          chevron_right
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="c__filter__item">
-                        {option.render ? option.render() : option.label}
-                        {(isSelected || option.isChecked) && (
-                          <span className="material-icons checked">check</span>
-                        )}
-                      </div>
-                    )
-                  }
+                  {({ isSelected }) => (
+                    <MenuItemBody
+                      label={option.render ? option.render() : option.label}
+                      isChecked={isSelected || option.isChecked}
+                      hasSubmenu={hasSubContent}
+                    />
+                  )}
                 </ListBoxItem>
                 {option.showSeparator && <Separator />}
               </Fragment>

--- a/src/components/menu/MenuItemBody.stories.tsx
+++ b/src/components/menu/MenuItemBody.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ReactNode } from "react";
+import { MenuItemBody } from "./MenuItemBody";
+
+/**
+ * `MenuItemBody` is the presentational inner content shared by every menu row:
+ * `DropdownMenu`, `ContextMenu` and `Filter`. It is **role-agnostic** — it emits
+ * only children (icon, label, optional subtext and a trailing check/chevron) and
+ * is meant to be rendered *inside* a react-aria `MenuItem` or `ListBoxItem`, both
+ * of which already carry the `c__dropdown-menu-item` class that styles it.
+ *
+ * You normally never render it directly — the menu components do that for you.
+ * These stories wrap it in the `c__dropdown-menu` / `c__dropdown-menu-item`
+ * markup so the layout matches what you get inside a real menu.
+ *
+ * ## Props
+ *
+ * | Prop | Type | Description |
+ * |------|------|-------------|
+ * | `icon` | `ReactNode` | Icon displayed on the left (wrapped in `__icon`) |
+ * | `label` | `ReactNode` | Main label content |
+ * | `subText` | `ReactNode` | Secondary text rendered below the label |
+ * | `isChecked` | `boolean` | Renders the trailing check icon |
+ * | `hasSubmenu` | `boolean` | Renders the trailing chevron (takes precedence over the check) |
+ */
+const meta = {
+  title: "Components/MenuItemBody",
+  component: MenuItemBody,
+  tags: ["autodocs"],
+  argTypes: {
+    icon: { control: false, description: "Icon displayed on the left" },
+    label: { control: "text", description: "Main label content" },
+    subText: { control: "text", description: "Secondary text below the label" },
+    isChecked: {
+      control: "boolean",
+      description: "Renders the trailing check icon",
+    },
+    hasSubmenu: {
+      control: "boolean",
+      description: "Renders the trailing chevron (takes precedence over check)",
+    },
+  },
+} satisfies Meta<typeof MenuItemBody>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Wraps children in the menu container markup that styles `MenuItemBody`. */
+const MenuPreview = ({ children }: { children: ReactNode }) => (
+  <div className="c__dropdown-menu" style={{ width: 240 }}>
+    {children}
+  </div>
+);
+
+/** A single styled menu row, mimicking what `MenuItem`/`ListBoxItem` provide. */
+const MenuRow = ({
+  children,
+  danger,
+}: {
+  children: ReactNode;
+  danger?: boolean;
+}) => (
+  <div
+    className={`c__dropdown-menu-item${danger ? " c__dropdown-menu-item--danger" : ""}`}
+  >
+    {children}
+  </div>
+);
+
+const icon = (name: string) => <span className="material-icons">{name}</span>;
+
+export const Default: Story = {
+  args: {
+    icon: icon("info"),
+    label: "Information",
+  },
+  render: (args) => (
+    <MenuPreview>
+      <MenuRow>
+        <MenuItemBody {...args} />
+      </MenuRow>
+    </MenuPreview>
+  ),
+};
+
+/** A secondary line of text rendered below the label. */
+export const WithSubText: Story = {
+  args: {
+    icon: icon("group"),
+    label: "Share",
+    subText: "Can share and manage access",
+  },
+  render: Default.render,
+};
+
+/** `isChecked` renders the trailing check icon, used for selection state. */
+export const Checked: Story = {
+  args: {
+    icon: icon("visibility"),
+    label: "Viewer",
+    isChecked: true,
+  },
+  render: Default.render,
+};
+
+/** `hasSubmenu` renders the trailing chevron and takes precedence over the check. */
+export const WithSubmenu: Story = {
+  args: {
+    icon: icon("share"),
+    label: "Share",
+    hasSubmenu: true,
+  },
+  render: Default.render,
+};
+
+/** Without an `icon`, the icon slot is omitted and the label aligns to the padding. */
+export const WithoutIcon: Story = {
+  args: {
+    label: "Rename",
+  },
+  render: Default.render,
+};
+
+/**
+ * The danger styling comes from the `c__dropdown-menu-item--danger` row class
+ * (set by the menu components), not from `MenuItemBody` itself.
+ */
+export const Danger: Story = {
+  args: {
+    icon: icon("delete"),
+    label: "Delete",
+  },
+  render: (args) => (
+    <MenuPreview>
+      <MenuRow danger>
+        <MenuItemBody {...args} />
+      </MenuRow>
+    </MenuPreview>
+  ),
+};
+
+/** Several rows together, showing how the variants line up inside a menu. */
+export const Gallery: Story = {
+  args: { label: "" },
+  render: () => (
+    <MenuPreview>
+      <MenuRow>
+        <MenuItemBody icon={icon("open_in_new")} label="Open" />
+      </MenuRow>
+      <MenuRow>
+        <MenuItemBody
+          icon={icon("group")}
+          label="Share"
+          subText="Can share and manage access"
+        />
+      </MenuRow>
+      <MenuRow>
+        <MenuItemBody icon={icon("visibility")} label="Viewer" isChecked />
+      </MenuRow>
+      <MenuRow>
+        <MenuItemBody icon={icon("drive_file_move")} label="Move to" hasSubmenu />
+      </MenuRow>
+      <MenuRow>
+        <MenuItemBody label="Rename" />
+      </MenuRow>
+      <MenuRow danger>
+        <MenuItemBody icon={icon("delete")} label="Delete" />
+      </MenuRow>
+    </MenuPreview>
+  ),
+};

--- a/src/components/menu/MenuItemBody.tsx
+++ b/src/components/menu/MenuItemBody.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from "react";
+
+export type MenuItemBodyProps = {
+  icon?: ReactNode;
+  label: ReactNode;
+  subText?: ReactNode;
+  /** Renders the trailing check icon (selected/checked state). */
+  isChecked?: boolean;
+  /** Renders the trailing chevron; takes precedence over the check icon. */
+  hasSubmenu?: boolean;
+};
+
+/**
+ * Presentational inner content shared by every menu row (DropdownMenu,
+ * ContextMenu, Filter). It is role-agnostic — it emits only children — so it
+ * renders correctly inside either a react-aria `MenuItem` or `ListBoxItem`,
+ * both of which already carry the `c__dropdown-menu-item` class that styles it.
+ */
+export const MenuItemBody = ({
+  icon,
+  label,
+  subText,
+  isChecked,
+  hasSubmenu,
+}: MenuItemBodyProps) => (
+  <>
+    {icon && <div className="c__dropdown-menu-item__icon">{icon}</div>}
+    <div className="c__dropdown-menu-item__label-container">
+      <div className="c__dropdown-menu-item__label">{label}</div>
+      {subText && (
+        <div className="c__dropdown-menu-item__label-subtext">{subText}</div>
+      )}
+    </div>
+    {hasSubmenu ? (
+      <span className="material-icons c__dropdown-menu-item__chevron">
+        chevron_right
+      </span>
+    ) : isChecked ? (
+      <span className="material-icons checked">check</span>
+    ) : null}
+  </>
+);

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,1 +1,3 @@
 export type { MenuItem, MenuItemAction, MenuItemSeparator } from "./types";
+export { MenuItemBody } from "./MenuItemBody";
+export type { MenuItemBodyProps } from "./MenuItemBody";


### PR DESCRIPTION
  ## What
  A `Filter` option can now declare `subContent` — it renders with a chevron and opens a
  hover sub-panel hosting any component. Showcase: an "Updated" filter whose **Custom**
  option opens a cunningham `CalendarRange`.

  ## Notes
  - Sub-content rows open on hover; clicking them is ignored (no select/close).
  - Checkmark now uses the `ListBoxItem` `isSelected` render prop (the collection pass
    doesn't have resolved Select state, so reading context was unreliable).
  - Migrated off deprecated react-aria props: `selectedKey`/`defaultSelectedKey`/
    `onSelectionChange` → `value`/`defaultValue`/`onChange` (old props still pass through).
- Added e2e tests

<img width="800" height="660" alt="CleanShot 2026-06-23 at 17 25 53" src="https://github.com/user-attachments/assets/8428fe0a-6054-4c7d-a357-537729083868" />
