### PR TITLE
✨(front) add SmartScroller component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 [UNRELEASED]
 
+## 0.24.0
+
 ### Minor Changes
 
 - ♿️(menu) add opensInNewWindow for external link aria-label #246
 - 🚸(LaGaufreV2) automatic positionning #260
 - ✨(filter) add custom sub-element support to options
 - ✨(help-menu) add legal links and custom options
+- ✨(front) add SmartScroller component
 
 ## 0.23.2
 

--- a/e2e/helpers/mount-smart-scroller.tsx
+++ b/e2e/helpers/mount-smart-scroller.tsx
@@ -1,0 +1,63 @@
+import { CunninghamProvider } from "../../src/components/Provider/Provider";
+import { SmartScroller } from "../../src/components/smart-scroller/SmartScroller";
+
+// Playwright CT bridges function props one-way, so tests declare scenarios via
+// plain data and this helper (which runs in the browser) builds the actual
+// children locally. The outer frame carries `data-testid="frame"` so resize
+// tests can change its width at runtime to trigger the component's
+// ResizeObserver.
+interface TestSmartScrollerProps {
+  /** Number of fixed-width items rendered inside the scroller. */
+  itemCount: number;
+  /** Forwarded to SmartScroller; defaults to its own default (0.5). */
+  scrollRatio?: number;
+  /** Width of the bounding frame the scroller must overflow against. */
+  frameWidth?: number;
+  /** Width of each item; `itemCount * itemWidth` decides whether it overflows. */
+  itemWidth?: number;
+}
+
+export const TestSmartScroller = ({
+  itemCount,
+  scrollRatio,
+  frameWidth = 480,
+  itemWidth = 120,
+}: TestSmartScrollerProps) => {
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <div
+        data-testid="frame"
+        style={{
+          width: frameWidth,
+          border: "1px solid var(--c--contextuals--border--surface--primary)",
+          borderRadius: 8,
+          padding: 8,
+        }}
+      >
+        <SmartScroller scrollRatio={scrollRatio}>
+          {Array.from({ length: itemCount }, (_, i) => (
+            <div
+              key={i}
+              data-testid={`item-${i}`}
+              style={{
+                flex: "0 0 auto",
+                width: itemWidth,
+                height: 40,
+                marginInline: 4,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                whiteSpace: "nowrap",
+                borderRadius: 20,
+                background:
+                  "var(--c--contextuals--background--surface--secondary)",
+              }}
+            >
+              Item {i + 1}
+            </div>
+          ))}
+        </SmartScroller>
+      </div>
+    </CunninghamProvider>
+  );
+};

--- a/e2e/smart-scroller/smart-scroller.spec.tsx
+++ b/e2e/smart-scroller/smart-scroller.spec.tsx
@@ -1,0 +1,159 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import type { Locator, Page } from "@playwright/test";
+import { TestSmartScroller } from "../helpers/mount-smart-scroller";
+
+const viewportOf = (page: Page) =>
+  page.locator(".c__smart-scroller__viewport");
+
+// The arrows are a pointer-only affordance (aria-hidden), so they are located
+// by class rather than by role/name.
+const rightArrowOf = (page: Page) =>
+  page.locator(".c__smart-scroller__arrow--right");
+const leftArrowOf = (page: Page) =>
+  page.locator(".c__smart-scroller__arrow--left");
+
+// Read a numeric geometry property off the scrollable viewport.
+const geom = (
+  viewport: Locator,
+  prop: "scrollLeft" | "clientWidth" | "scrollWidth",
+) => viewport.evaluate((el, p) => el[p as keyof Element] as number, prop);
+
+// Poll until the smooth scroll has settled, then return the resting scrollLeft.
+const settledScrollLeft = async (viewport: Locator) => {
+  let last = -1;
+  await expect
+    .poll(async () => {
+      const current = await geom(viewport, "scrollLeft");
+      const stable = current === last;
+      last = current;
+      return stable ? "stable" : current;
+    })
+    .toBe("stable");
+  return last;
+};
+
+test.describe("SmartScroller", () => {
+  test("renders no arrows when content fits", async ({ mount, page }) => {
+    await mount(<TestSmartScroller itemCount={2} />);
+    await expect(viewportOf(page)).toBeVisible();
+
+    await expect(rightArrowOf(page)).toHaveCount(0);
+    await expect(leftArrowOf(page)).toHaveCount(0);
+  });
+
+  test("shows only the right arrow when content overflows at the start", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+
+    await expect(rightArrowOf(page)).toBeVisible();
+    await expect(leftArrowOf(page)).toHaveCount(0);
+    expect(await geom(viewportOf(page), "scrollLeft")).toBe(0);
+  });
+
+  test("hides the arrows from assistive technology", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+
+    // The visible arrow is aria-hidden, so it is absent from the a11y tree...
+    await expect(rightArrowOf(page)).toBeVisible();
+    await expect(rightArrowOf(page)).toHaveAttribute("aria-hidden", "true");
+    await expect(
+      page.getByRole("button", { name: "Scroll right" }),
+    ).toHaveCount(0);
+
+    // ...and removed from the tab order.
+    await expect(rightArrowOf(page)).toHaveAttribute("tabindex", "-1");
+  });
+
+  test("clicking the right arrow scrolls ~50% of the viewport width", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+    const viewport = viewportOf(page);
+
+    const clientWidth = await geom(viewport, "clientWidth");
+    await rightArrowOf(page).click();
+
+    const scrollLeft = await settledScrollLeft(viewport);
+    expect(Math.abs(scrollLeft - clientWidth * 0.5)).toBeLessThanOrEqual(2);
+  });
+
+  test("scrolling right reveals the left arrow", async ({ mount, page }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+
+    await rightArrowOf(page).click();
+
+    await expect(leftArrowOf(page)).toBeVisible();
+  });
+
+  test("clicking the left arrow scrolls back toward the start", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+    const viewport = viewportOf(page);
+
+    await rightArrowOf(page).click();
+    const afterRight = await settledScrollLeft(viewport);
+    expect(afterRight).toBeGreaterThan(0);
+
+    await leftArrowOf(page).click();
+    const afterLeft = await settledScrollLeft(viewport);
+    expect(afterLeft).toBeLessThan(afterRight);
+  });
+
+  test("reaching the end hides the right arrow and keeps the left arrow", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} />);
+    const viewport = viewportOf(page);
+
+    await viewport.evaluate((el) => {
+      el.scrollLeft = el.scrollWidth;
+    });
+
+    await expect(rightArrowOf(page)).toHaveCount(0);
+    await expect(leftArrowOf(page)).toBeVisible();
+  });
+
+  test("scrollRatio of 1 scrolls a full viewport width", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSmartScroller itemCount={15} scrollRatio={1} />);
+    const viewport = viewportOf(page);
+
+    const clientWidth = await geom(viewport, "clientWidth");
+    await rightArrowOf(page).click();
+
+    const scrollLeft = await settledScrollLeft(viewport);
+    expect(Math.abs(scrollLeft - clientWidth)).toBeLessThanOrEqual(2);
+  });
+
+  test("recomputes arrows when the container is resized", async ({
+    mount,
+    page,
+  }) => {
+    // 3 items (~360px) fit the 480px frame: no arrows.
+    await mount(<TestSmartScroller itemCount={3} />);
+    await expect(rightArrowOf(page)).toHaveCount(0);
+
+    // Shrinking the frame makes the same content overflow -> right arrow shows.
+    await page.getByTestId("frame").evaluate((el) => {
+      (el as HTMLElement).style.width = "200px";
+    });
+    await expect(rightArrowOf(page)).toBeVisible();
+
+    // Growing it back past the content width hides the arrow again.
+    await page.getByTestId("frame").evaluate((el) => {
+      (el as HTMLElement).style.width = "480px";
+    });
+    await expect(rightArrowOf(page)).toHaveCount(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.23.2",
+  "version": "0.24.0",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/components/smart-scroller/SmartScroller.mdx
+++ b/src/components/smart-scroller/SmartScroller.mdx
@@ -1,0 +1,50 @@
+import { Meta, Canvas, ArgTypes } from "@storybook/blocks";
+import * as SmartScrollerStories from "./smart-scroller.stories";
+
+<Meta of={SmartScrollerStories} name="Docs" />
+
+# SmartScroller
+
+`SmartScroller` is a container that makes its content horizontally scrollable and overlays an arrow button on each edge where content is hidden by overflow. Clicking an arrow scrolls the viewport by half of its visible width (configurable). It is well suited to horizontal toolbars, tab strips, chip rows, or any single row of items that may not fit the available width.
+
+The component handles everything itself: it measures overflow, shows or hides each arrow as needed, and hides the native scrollbar so the arrows are the primary affordance. Content still scrolls with the wheel/trackpad.
+
+## Usage
+
+```tsx
+import { SmartScroller } from "@gouvfr-lasuite/ui-kit";
+
+<SmartScroller>
+  <Chip>Item 1</Chip>
+  <Chip>Item 2</Chip>
+  <Chip>Item 3</Chip>
+  {/* … */}
+</SmartScroller>;
+```
+
+The styles are bundled in `@gouvfr-lasuite/ui-kit/style`, so make sure it is imported once in your app.
+
+Children are laid out in a single row sized to their content, so the container overflows horizontally once the items exceed the available width. Give the `SmartScroller` a bounded width (or place it in a width-constrained parent) so there is an edge to overflow against.
+
+## Behaviour
+
+- An arrow is rendered **only** on the side(s) where there is hidden content: the right arrow appears when there is more content to the right, the left arrow once you have scrolled away from the start. Each arrow disappears as soon as its edge is fully reached.
+- A subtle gradient fade is drawn on every scrollable edge to hint at the partially-cut content underneath. The fade never intercepts clicks.
+- Overflow is recomputed on scroll and whenever the container **or** its content is resized (e.g. items added or removed, the viewport shrinking), so the arrows always reflect the current state.
+- Scrolling on click is smooth, and respects the user's `prefers-reduced-motion` setting.
+
+<Canvas of={SmartScrollerStories.Overflowing} />
+
+When the content fits within the container, no arrows are shown:
+
+<Canvas of={SmartScrollerStories.NoOverflow} />
+
+## Props
+
+<ArgTypes of={SmartScrollerStories} />
+
+## Responsive resizing
+
+Because the arrows are derived from a live measurement, they stay correct when the container is resized — for example inside a resizable panel or a responsive layout. Drag the frame below to see the arrows recompute as the available width changes:
+
+<Canvas of={SmartScrollerStories.Resizable} />

--- a/src/components/smart-scroller/SmartScroller.tsx
+++ b/src/components/smart-scroller/SmartScroller.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import { Button } from "@gouvfr-lasuite/cunningham-react";
+import { IconSize } from ":/components/icon";
+import { ArrowLeft, ArrowRight } from ":/icons";
+
+export type SmartScrollerProps = {
+  children: React.ReactNode;
+  /** Custom CSS class applied to the root element. */
+  className?: string;
+  /**
+   * Fraction of the visible width scrolled on each arrow click.
+   * Defaults to 0.5 (half the viewport).
+   */
+  scrollRatio?: number;
+};
+
+/**
+ * A horizontally scrollable container that overlays arrow buttons on the
+ * edges where content is hidden by overflow. Clicking an arrow scrolls the
+ * viewport by `scrollRatio` of its visible width (smoothly). Each arrow only
+ * shows while there is content to reveal on that side, and a gradient fade
+ * hints at the partially-cut content underneath.
+ */
+export const SmartScroller = ({
+  children,
+  className,
+  scrollRatio = 0.5,
+}: SmartScrollerProps) => {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateArrows = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+    const { scrollLeft, clientWidth, scrollWidth } = viewport;
+    setCanScrollLeft(scrollLeft > 0);
+    // 1px tolerance absorbs sub-pixel rounding so the right arrow hides once
+    // the end is reached.
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+  }, []);
+
+  // Measure on mount, on scroll, and whenever the viewport (container) or its
+  // content (children added/removed/grown) is resized.
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+    if (!viewport || !content) {
+      return;
+    }
+    updateArrows();
+    viewport.addEventListener("scroll", updateArrows, { passive: true });
+    const observer = new ResizeObserver(updateArrows);
+    observer.observe(viewport);
+    observer.observe(content);
+    return () => {
+      viewport.removeEventListener("scroll", updateArrows);
+      observer.disconnect();
+    };
+  }, [updateArrows]);
+
+  const scrollByRatio = (direction: 1 | -1) => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+    viewport.scrollBy({
+      left: direction * viewport.clientWidth * scrollRatio,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <div className={clsx("c__smart-scroller", className)}>
+      {canScrollLeft && (
+        <>
+          <span className="c__smart-scroller__fade c__smart-scroller__fade--left" />
+          <Button
+            className="c__smart-scroller__arrow c__smart-scroller__arrow--left"
+            onClick={() => scrollByRatio(-1)}
+            // Pointer-only affordance: assistive-tech and keyboard users reach
+            // the content directly (focusing a child scrolls it into view), so
+            // the arrows are hidden from the a11y tree and the tab order.
+            aria-hidden="true"
+            tabIndex={-1}
+            icon={<ArrowLeft size={IconSize.SMALL} />}
+            color="neutral"
+            variant="bordered"
+            size="small"
+          />
+        </>
+      )}
+
+      <div className="c__smart-scroller__viewport" ref={viewportRef}>
+        <div className="c__smart-scroller__content" ref={contentRef}>
+          {children}
+        </div>
+      </div>
+
+      {canScrollRight && (
+        <>
+          <span className="c__smart-scroller__fade c__smart-scroller__fade--right" />
+          <Button
+            className="c__smart-scroller__arrow c__smart-scroller__arrow--right"
+            onClick={() => scrollByRatio(1)}
+            aria-hidden="true"
+            tabIndex={-1}
+            icon={<ArrowRight size={IconSize.SMALL} />}
+            color="neutral"
+            variant="bordered"
+            size="small"
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/smart-scroller/index.scss
+++ b/src/components/smart-scroller/index.scss
@@ -1,0 +1,87 @@
+// The native scrollbar is hidden so the arrows are the primary affordance;
+// the content still scrolls with the wheel/trackpad and the arrow buttons.
+// An arrow (and its gradient fade) is only rendered by the component on the
+// side(s) where hidden content exists.
+
+$arrow-size: 28px;
+$fade-width: 48px;
+
+.c__smart-scroller {
+  position: relative;
+  width: 100%;
+
+  &__viewport {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-behavior: smooth;
+
+    // Hide the native scrollbar (the arrows replace it).
+    scrollbar-width: none; // Firefox
+    -ms-overflow-style: none; // legacy Edge
+    &::-webkit-scrollbar {
+      display: none; // Chrome / Safari
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      scroll-behavior: auto;
+    }
+  }
+
+  // Lay children out in a single row sized to their content so the viewport
+  // can overflow horizontally.
+  &__content {
+    display: flex;
+    width: max-content;
+  }
+
+  // Gradient hint over the partially-cut content. Sits under the arrow button
+  // and never intercepts pointer events.
+  &__fade {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: $fade-width;
+    z-index: 1;
+    pointer-events: none;
+    backdrop-filter: blur(1px);
+
+    &--left {
+      left: 0;
+      background: linear-gradient(
+        to right,
+        var(--c--contextuals--background--surface--primary) 75%,
+        transparent 100%
+      );
+    }
+
+    &--right {
+      right: 0;
+      background: linear-gradient(
+        to left,
+        var(--c--contextuals--background--surface--primary) 75%,
+        transparent 100%
+      );
+    }
+  }
+
+  // Floating circular button overlaying the edge of the content.
+  &__arrow.c__smart-scroller__arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 2;
+
+    border-radius: 8px;
+    border-color: var(--c--contextuals--border--surface--primary);
+
+    background-color: var(--c--contextuals--background--surface--primary);
+
+    &--left {
+      left: var(--c--globals--spacings--3xs);
+    }
+
+    &--right {
+      right: var(--c--globals--spacings--3xs);
+    }
+  }
+}

--- a/src/components/smart-scroller/index.tsx
+++ b/src/components/smart-scroller/index.tsx
@@ -1,0 +1,1 @@
+export * from "./SmartScroller";

--- a/src/components/smart-scroller/smart-scroller.stories.tsx
+++ b/src/components/smart-scroller/smart-scroller.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SmartScroller } from "./SmartScroller";
+
+const meta: Meta<typeof SmartScroller> = {
+  title: "Components/SmartScroller",
+  component: SmartScroller,
+  argTypes: {
+    children: {
+      description: "The content laid out as a horizontally scrollable row.",
+      control: false,
+      table: { type: { summary: "React.ReactNode" } },
+    },
+    className: {
+      description: "Custom CSS class applied to the root element.",
+      table: { type: { summary: "string" } },
+    },
+    scrollRatio: {
+      description:
+        "Fraction of the visible width scrolled on each arrow click " +
+        "(e.g. 0.5 = half the viewport, 1 = a full page).",
+      table: { type: { summary: "number" }, defaultValue: { summary: "0.5" } },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SmartScroller>;
+
+const frameStyle: React.CSSProperties = {
+  width: 480,
+  marginBottom: 32,
+  border: "1px solid var(--c--contextuals--border--surface--primary)",
+  borderRadius: 8,
+  padding: 8,
+};
+
+const chipStyle: React.CSSProperties = {
+  flex: "0 0 auto",
+  height: 40,
+  paddingInline: 20,
+  marginInline: 4,
+  display: "flex",
+  alignItems: "center",
+  whiteSpace: "nowrap",
+  borderRadius: 20,
+  background: "var(--c--contextuals--background--surface--secondary)",
+  color: "var(--c--contextuals--content--semantic--neutral--primary)",
+};
+
+const Chips = ({ count }: { count: number }) => (
+  <>
+    {Array.from({ length: count }, (_, i) => (
+      <div key={i} style={chipStyle}>
+        Item {i + 1}
+      </div>
+    ))}
+  </>
+);
+
+// Many items overflow the frame: the right arrow shows immediately, scrolling
+// reveals the left arrow, and reaching the end hides the right arrow.
+export const Overflowing: Story = {
+  render: () => (
+    <div style={frameStyle}>
+      <SmartScroller>
+        <Chips count={15} />
+      </SmartScroller>
+    </div>
+  ),
+};
+
+// Few items that fit within the frame: no arrows are rendered.
+export const NoOverflow: Story = {
+  render: () => (
+    <div style={frameStyle}>
+      <SmartScroller>
+        <Chips count={3} />
+      </SmartScroller>
+    </div>
+  ),
+};
+
+// Resize the frame (drag its bottom-right corner) to confirm the arrows
+// recompute as the available width changes.
+export const Resizable: Story = {
+  render: () => (
+    <div style={{ ...frameStyle, resize: "horizontal", overflow: "auto" }}>
+      <SmartScroller>
+        <Chips count={15} />
+      </SmartScroller>
+    </div>
+  ),
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from "./components/loader";
 export * from "./components/form";
 export * from "./components/quick-search";
 export * from "./components/separator";
+export * from "./components/smart-scroller";
 export * from "./components/tabs";
 export * from "./components/tree-view";
 export * from "./components/form/label/label";

--- a/src/library.scss
+++ b/src/library.scss
@@ -17,6 +17,7 @@
 @use "./components/quick-search/quick-search-global-style";
 @use "./components/separator";
 @use "./components/resize-handle";
+@use "./components/smart-scroller";
 @use "./components/form/label";
 @use "./components/tabs";
 @use "./components/form/switch";


### PR DESCRIPTION
Adds **`SmartScroller`**: a horizontally scrollable container that overlays an arrow on each edge where content overflows. Clicking scrolls the viewport by `scrollRatio` of its visible width (default 50%), smoothly.

<img width="800" height="180" alt="CleanShot 2026-06-24 at 16 02 25" src="https://github.com/user-attachments/assets/a661a422-f501-4c5a-abc0-a9ad519d044f" />

From

https://www.figma.com/design/hPwxE24MEaX3mBQ0KXNTSY/UI-kit?node-id=14537-7383&m=dev
