### PR TITLE
📱(user-menu) add withMobileView prop to hide mobile view rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [UNRELEASED]
 
+### Minor Changes
+
+- 🐛(tree-view) remove pointer-events rules breaking drag-and-drop #215
+- 📱(user-menu) add withMobileView prop to hide mobile view rendering #264
+
 ## 0.24.0
 
 ### Minor Changes
@@ -11,7 +16,6 @@
 - ✨(filter) add custom sub-element support to options
 - ✨(help-menu) add legal links and custom options
 - ✨(front) add SmartScroller component
-- 🐛(tree-view) remove pointer-events rules breaking drag-and-drop #215
 
 ## 0.23.2
 

--- a/src/components/users/menu/index.stories.tsx
+++ b/src/components/users/menu/index.stories.tsx
@@ -98,3 +98,12 @@ export const WithNoFullName: Story = {
     },
   },
 };
+
+export const WithNoMobileView: Story = {
+  args: {
+    user: {
+      email: "jane.doe@example.com",
+    },
+    withMobileView: false,
+  },
+};

--- a/src/components/users/menu/index.tsx
+++ b/src/components/users/menu/index.tsx
@@ -196,6 +196,7 @@ export type UserMenuProps = {
   termOfServiceUrl?: string;
   isInitialOpen?: boolean;
   actions?: ReactElement;
+  withMobileView?: boolean;
 };
 
 export const UserMenu = ({
@@ -204,6 +205,7 @@ export const UserMenu = ({
   logout,
   termOfServiceUrl,
   actions,
+  withMobileView = true,
 }: UserMenuProps) => {
   const { t } = useCunningham();
   const { isTablet } = useResponsive();
@@ -238,7 +240,7 @@ export const UserMenu = ({
 
   return (
     <>
-      {isTablet ? (
+      {withMobileView && isTablet ? (
         <UserMenuMobile
           user={user}
           settingsItems={settingsItems}


### PR DESCRIPTION
## Purpose

Some apps try to have a mobile experience as close to the desktop experience as possible, to provide a consistent user interface across all devices.
This props allows the app to use only the desktop view of the user menu, even on mobile devices.

## Demo

<img width="362" height="346" alt="image" src="https://github.com/user-attachments/assets/ea01d6b5-d460-4569-8180-7a5122e038c2" />


https://github.com/user-attachments/assets/fe6f3346-8dce-4121-8bd9-65be35479f25


