### PR TITLE
♻️(front) keep SmartScroller arrows mounted for smooth fades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Patch CHanges
 
 - 🐛(front) dismiss filter sub-panel on click outside, not hover out
-- 
+- ♻️(front) keep SmartScroller arrows mounted for smooth fades
+- ♻️(front) improve SmartScroller blurry gradient
+- 🐛(front) fix SmartScroller button background
 
 ## 0.25.0
 
@@ -45,7 +47,7 @@
 
 ### Major Changes
 
-- 💥(frontend) add dedicated icons entrypoint 
+- 💥(frontend) add dedicated icons entrypoint
 
 ### Patch Changes
 

--- a/e2e/smart-scroller/smart-scroller.spec.tsx
+++ b/e2e/smart-scroller/smart-scroller.spec.tsx
@@ -12,6 +12,18 @@ const rightArrowOf = (page: Page) =>
 const leftArrowOf = (page: Page) =>
   page.locator(".c__smart-scroller__arrow--left");
 
+// The arrows stay mounted and fade via opacity (for smooth transitions), so
+// shown/hidden is asserted on the computed style rather than on DOM presence.
+// While hidden they must also be click-through so they never block content.
+const expectArrowShown = async (arrow: Locator) => {
+  await expect(arrow).toHaveCSS("opacity", "1");
+  await expect(arrow).toHaveCSS("pointer-events", "auto");
+};
+const expectArrowHidden = async (arrow: Locator) => {
+  await expect(arrow).toHaveCSS("opacity", "0");
+  await expect(arrow).toHaveCSS("pointer-events", "none");
+};
+
 // Read a numeric geometry property off the scrollable viewport.
 const geom = (
   viewport: Locator,
@@ -33,12 +45,12 @@ const settledScrollLeft = async (viewport: Locator) => {
 };
 
 test.describe("SmartScroller", () => {
-  test("renders no arrows when content fits", async ({ mount, page }) => {
+  test("shows no arrows when content fits", async ({ mount, page }) => {
     await mount(<TestSmartScroller itemCount={2} />);
     await expect(viewportOf(page)).toBeVisible();
 
-    await expect(rightArrowOf(page)).toHaveCount(0);
-    await expect(leftArrowOf(page)).toHaveCount(0);
+    await expectArrowHidden(rightArrowOf(page));
+    await expectArrowHidden(leftArrowOf(page));
   });
 
   test("shows only the right arrow when content overflows at the start", async ({
@@ -47,8 +59,8 @@ test.describe("SmartScroller", () => {
   }) => {
     await mount(<TestSmartScroller itemCount={15} />);
 
-    await expect(rightArrowOf(page)).toBeVisible();
-    await expect(leftArrowOf(page)).toHaveCount(0);
+    await expectArrowShown(rightArrowOf(page));
+    await expectArrowHidden(leftArrowOf(page));
     expect(await geom(viewportOf(page), "scrollLeft")).toBe(0);
   });
 
@@ -59,7 +71,7 @@ test.describe("SmartScroller", () => {
     await mount(<TestSmartScroller itemCount={15} />);
 
     // The visible arrow is aria-hidden, so it is absent from the a11y tree...
-    await expect(rightArrowOf(page)).toBeVisible();
+    await expectArrowShown(rightArrowOf(page));
     await expect(rightArrowOf(page)).toHaveAttribute("aria-hidden", "true");
     await expect(
       page.getByRole("button", { name: "Scroll right" }),
@@ -88,7 +100,7 @@ test.describe("SmartScroller", () => {
 
     await rightArrowOf(page).click();
 
-    await expect(leftArrowOf(page)).toBeVisible();
+    await expectArrowShown(leftArrowOf(page));
   });
 
   test("clicking the left arrow scrolls back toward the start", async ({
@@ -118,8 +130,8 @@ test.describe("SmartScroller", () => {
       el.scrollLeft = el.scrollWidth;
     });
 
-    await expect(rightArrowOf(page)).toHaveCount(0);
-    await expect(leftArrowOf(page)).toBeVisible();
+    await expectArrowHidden(rightArrowOf(page));
+    await expectArrowShown(leftArrowOf(page));
   });
 
   test("scrollRatio of 1 scrolls a full viewport width", async ({
@@ -142,18 +154,18 @@ test.describe("SmartScroller", () => {
   }) => {
     // 3 items (~360px) fit the 480px frame: no arrows.
     await mount(<TestSmartScroller itemCount={3} />);
-    await expect(rightArrowOf(page)).toHaveCount(0);
+    await expectArrowHidden(rightArrowOf(page));
 
     // Shrinking the frame makes the same content overflow -> right arrow shows.
     await page.getByTestId("frame").evaluate((el) => {
       (el as HTMLElement).style.width = "200px";
     });
-    await expect(rightArrowOf(page)).toBeVisible();
+    await expectArrowShown(rightArrowOf(page));
 
     // Growing it back past the content width hides the arrow again.
     await page.getByTestId("frame").evaluate((el) => {
       (el as HTMLElement).style.width = "480px";
     });
-    await expect(rightArrowOf(page)).toHaveCount(0);
+    await expectArrowHidden(rightArrowOf(page));
   });
 });

--- a/src/components/smart-scroller/SmartScroller.tsx
+++ b/src/components/smart-scroller/SmartScroller.tsx
@@ -76,24 +76,33 @@ export const SmartScroller = ({
 
   return (
     <div className={clsx("c__smart-scroller", className)}>
-      {canScrollLeft && (
-        <>
-          <span className="c__smart-scroller__fade c__smart-scroller__fade--left" />
-          <Button
-            className="c__smart-scroller__arrow c__smart-scroller__arrow--left"
-            onClick={() => scrollByRatio(-1)}
-            // Pointer-only affordance: assistive-tech and keyboard users reach
-            // the content directly (focusing a child scrolls it into view), so
-            // the arrows are hidden from the a11y tree and the tab order.
-            aria-hidden="true"
-            tabIndex={-1}
-            icon={<ArrowLeft size={IconSize.SMALL} />}
-            color="neutral"
-            variant="bordered"
-            size="small"
-          />
-        </>
-      )}
+      {/*
+       * Arrows and fades stay mounted and toggle visibility via a modifier
+       * class so their opacity transitions smoothly as scrollability changes
+       * (mounting/unmounting would make them pop in and out instantly).
+       */}
+      <span
+        className={clsx(
+          "c__smart-scroller__fade c__smart-scroller__fade--left",
+          canScrollLeft && "c__smart-scroller__fade--visible"
+        )}
+      />
+      <Button
+        className={clsx(
+          "c__smart-scroller__arrow c__smart-scroller__arrow--left",
+          canScrollLeft && "c__smart-scroller__arrow--visible"
+        )}
+        onClick={() => scrollByRatio(-1)}
+        // Pointer-only affordance: assistive-tech and keyboard users reach
+        // the content directly (focusing a child scrolls it into view), so
+        // the arrows are hidden from the a11y tree and the tab order.
+        aria-hidden="true"
+        tabIndex={-1}
+        icon={<ArrowLeft size={IconSize.SMALL} />}
+        color="neutral"
+        variant="bordered"
+        size="small"
+      />
 
       <div className="c__smart-scroller__viewport" ref={viewportRef}>
         <div className="c__smart-scroller__content" ref={contentRef}>
@@ -101,21 +110,25 @@ export const SmartScroller = ({
         </div>
       </div>
 
-      {canScrollRight && (
-        <>
-          <span className="c__smart-scroller__fade c__smart-scroller__fade--right" />
-          <Button
-            className="c__smart-scroller__arrow c__smart-scroller__arrow--right"
-            onClick={() => scrollByRatio(1)}
-            aria-hidden="true"
-            tabIndex={-1}
-            icon={<ArrowRight size={IconSize.SMALL} />}
-            color="neutral"
-            variant="bordered"
-            size="small"
-          />
-        </>
-      )}
+      <span
+        className={clsx(
+          "c__smart-scroller__fade c__smart-scroller__fade--right",
+          canScrollRight && "c__smart-scroller__fade--visible"
+        )}
+      />
+      <Button
+        className={clsx(
+          "c__smart-scroller__arrow c__smart-scroller__arrow--right",
+          canScrollRight && "c__smart-scroller__arrow--visible"
+        )}
+        onClick={() => scrollByRatio(1)}
+        aria-hidden="true"
+        tabIndex={-1}
+        icon={<ArrowRight size={IconSize.SMALL} />}
+        color="neutral"
+        variant="bordered"
+        size="small"
+      />
     </div>
   );
 };

--- a/src/components/smart-scroller/index.scss
+++ b/src/components/smart-scroller/index.scss
@@ -4,7 +4,7 @@
 // side(s) where hidden content exists.
 
 $arrow-size: 28px;
-$fade-width: 48px;
+$fade-width: 64px;
 
 .c__smart-scroller {
   position: relative;
@@ -45,22 +45,37 @@ $fade-width: 48px;
     pointer-events: none;
     backdrop-filter: blur(1px);
 
+    // Hidden until there is content to reveal on this side; fades in/out.
+    opacity: 0;
+    transition: opacity 0.2s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+
+    &--visible {
+      opacity: 1;
+    }
+
     &--left {
       left: 0;
       background: linear-gradient(
         to right,
-        var(--c--contextuals--background--surface--primary) 75%,
-        transparent 100%
+        rgb(255, 255, 255) 0%,
+        rgba(255, 255, 255, 0) 100%
       );
+
+      mask-image: linear-gradient(to right, black 50%, transparent 100%);
     }
 
     &--right {
       right: 0;
       background: linear-gradient(
         to left,
-        var(--c--contextuals--background--surface--primary) 75%,
-        transparent 100%
+        rgb(255, 255, 255) 0%,
+        rgba(255, 255, 255, 0) 100%
       );
+      mask-image: linear-gradient(to left, black 50%, transparent 100%);
     }
   }
 
@@ -74,7 +89,33 @@ $fade-width: 48px;
     border-radius: 8px;
     border-color: var(--c--contextuals--border--surface--primary);
 
+    // By default the neutral bordered button has a partially transparent background,
+      // that would not work properly for this component. We need to use a solid background.
     background-color: var(--c--contextuals--background--surface--primary);
+
+    // Hidden until there is content to reveal on this side; fades in/out.
+    // pointer-events are disabled while hidden so it never blocks the content
+    // underneath.
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+
+    &--visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--c--contextuals--background--semantic--neutral--secondary),
+        white 70%
+      );
+    }
 
     &--left {
       left: var(--c--globals--spacings--3xs);


### PR DESCRIPTION
The arrows and fades were mounted/unmounted with the scrollability state, so they popped in and out instantly. Keeping them mounted and toggling a --visible modifier lets their opacity transition, and pointer-events are disabled while hidden so they never block content. The fade gradients also get a mask for a softer edge.

Also improve SmartScroller blurry gradient and arrow button hover state.

# Before

<img width="800" height="168" alt="CleanShot 2026-07-01 at 10 25 51" src="https://github.com/user-attachments/assets/f5977a48-4efb-48a4-b62b-6edfa7c74d77" />

# After

<img width="800" height="159" alt="CleanShot 2026-07-01 at 10 25 20" src="https://github.com/user-attachments/assets/d6d1ccfe-8782-44a4-bab8-747816226e28" />
