### PR TITLE
🐛(front) fix filter sub-panel dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [UNRELEASED]
 
+### Patch CHanges
+
+- 🐛(front) dismiss filter sub-panel on click outside, not hover out
+- 
+
 ## 0.25.0
 
 ### Minor Changes

--- a/e2e/filter/filter.spec.tsx
+++ b/e2e/filter/filter.spec.tsx
@@ -74,6 +74,52 @@ test.describe("Filter", () => {
     await expect(page.getByRole("grid")).toBeVisible();
   });
 
+  test("keeps the sub-panel open when the pointer leaves it", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+
+    // Moving the pointer away used to close the panel after a 150ms delay. It
+    // must now stay open until an explicit click outside, so wait past that old
+    // delay and assert it is still there.
+    await page.getByRole("option", { name: "Today" }).hover();
+    await page.waitForTimeout(300);
+    await expect(page.getByRole("grid")).toBeVisible();
+  });
+
+  test("clicking outside closes the sub-panel", async ({ page }) => {
+    await page.getByRole("button", { name: /Updated/ }).click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+
+    // A click away from the panel and its row dismisses it.
+    await page.mouse.click(1200, 650);
+
+    await expect(page.getByRole("grid")).not.toBeVisible();
+  });
+
+  test("selecting another option closes an open sub-panel", async ({
+    page,
+  }) => {
+    const trigger = page.getByRole("button", { name: /Updated/ });
+    await trigger.click();
+
+    await page.getByRole("option", { name: "Custom" }).hover();
+    await expect(page.getByRole("grid")).toBeVisible();
+
+    // Selecting any option dismisses a lingering sub-panel along with the
+    // dropdown.
+    await page.getByRole("option", { name: "Today" }).click();
+
+    await expect(page.getByRole("grid")).not.toBeVisible();
+    await expect(page.getByRole("listbox")).not.toBeVisible();
+    await expect(trigger).toHaveAccessibleName("Updated : Today");
+  });
+
   test("opens the sub-panel with the keyboard and restores focus on Escape", async ({
     page,
   }) => {

--- a/src/components/filter/Filter.stories.tsx
+++ b/src/components/filter/Filter.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Filter, FilterOption } from "./Filter";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Key } from "react-aria-components";
 import { Button, CalendarRange } from "@gouvfr-lasuite/cunningham-react";
 import { DateValue } from "@internationalized/date";
@@ -338,18 +338,26 @@ export const UpdatedWithDateRange: Story = {
       setRange(null);
     };
 
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const pendingRangeRef = useRef<DateRangeValue | null>(null);
+
     const options: FilterOption[] = [
       { label: "Today", value: "today" },
       { label: "Yesterday", value: "yesterday" },
       { label: "Last week", value: "lastWeek", showSeparator: true },
       {
-        label: range ? formatRange(range) : "Custom",
+        label: range && selected === "custom" ? formatRange(range) : "Custom",
         value: "custom",
         subContent: ({ select, close }) => (
           <CalendarRange
-            value={range}
-            onChange={setRange}
+            onChange={(range) => {
+              pendingRangeRef.current = range;
+            }}
             onOk={() => {
+              const picked = pendingRangeRef.current;
+              if (picked) {
+                setRange(picked);
+              }
               select();
               close();
             }}

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -74,7 +74,6 @@ export const Filter = (props: FilterProps) => {
   // Set from within the Select so the out-of-tree sub-panel can drive selection.
   const selectStateRef = useRef<SelectStateLike | null>(null);
 
-  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [openKey, setOpenKey] = useState<string | null>(null);
 
   // The content of the currently-open sub-panel, used to move focus into it when
@@ -82,21 +81,34 @@ export const Filter = (props: FilterProps) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const focusOnOpen = useRef(false);
 
-  const cancelClose = () => {
-    if (closeTimeout.current) {
-      clearTimeout(closeTimeout.current);
-      closeTimeout.current = null;
-    }
-  };
   const openSub = (value: string, withFocus = false) => {
-    cancelClose();
     focusOnOpen.current = withFocus;
     setOpenKey(value);
   };
-  const scheduleClose = () => {
-    cancelClose();
-    closeTimeout.current = setTimeout(() => setOpenKey(null), 150);
-  };
+
+  // Close the open sub-panel on a click outside of it. react-aria disables its
+  // own interact-outside dismissal for non-modal popovers (`isDismissable` is
+  // false unless it is a submenu), so we handle it ourselves. Clicks on the
+  // panel or on its trigger row keep it open; anything else dismisses it.
+  useEffect(() => {
+    if (!openKey) {
+      return;
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const row = getRowRef(openKey).current;
+      if (target.closest(".c__filter__subpanel") || row?.contains(target)) {
+        return;
+      }
+      setOpenKey(null);
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () =>
+      document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [openKey]);
 
   // When a sub-panel is opened via keyboard, move focus to its first focusable
   // element so it is operable without a pointer.
@@ -117,12 +129,20 @@ export const Filter = (props: FilterProps) => {
 
   return (
     <>
-      <Select {...props} className="c__filter">
+      <Select
+        {...props}
+        className="c__filter"
+        onSelectionChange={(key) => {
+          // Selecting an option changes the Filter value; dismiss any open
+          // sub-panel so a stale sub-content popover never lingers.
+          setOpenKey(null);
+          props.onSelectionChange?.(key);
+        }}
+      >
         <FilterInner
           {...props}
           getRowRef={getRowRef}
           openSub={openSub}
-          scheduleClose={scheduleClose}
           selectStateRef={selectStateRef}
         />
       </Select>
@@ -132,13 +152,13 @@ export const Filter = (props: FilterProps) => {
         const helpers: FilterSubContentHelpers = {
           select: () => selectStateRef.current?.setValue(value),
           close: () => {
-            cancelClose();
             setOpenKey(null);
             selectStateRef.current?.close();
           },
         };
         return (
           <Popover
+            offset={0}
             key={value}
             triggerRef={getRowRef(value)}
             isOpen={openKey === value}
@@ -159,11 +179,7 @@ export const Filter = (props: FilterProps) => {
             placement="right top"
             className="c__filter__subpanel"
           >
-            <div
-              ref={openKey === value ? panelRef : undefined}
-              onMouseEnter={cancelClose}
-              onMouseLeave={scheduleClose}
-            >
+            <div ref={openKey === value ? panelRef : undefined}>
               {option.subContent?.(helpers)}
             </div>
           </Popover>
@@ -176,13 +192,11 @@ export const Filter = (props: FilterProps) => {
 type FilterInnerProps = FilterProps & {
   getRowRef: (value: string) => RefObject<HTMLDivElement | null>;
   openSub: (value: string, withFocus?: boolean) => void;
-  scheduleClose: () => void;
   selectStateRef: RefObject<SelectStateLike | null>;
 };
 
 const FilterInner = (props: FilterInnerProps) => {
-  const { getRowRef, openSub, scheduleClose, selectStateRef, ...filterProps } =
-    props;
+  const { getRowRef, openSub, selectStateRef, ...filterProps } = props;
   const state = useContext(SelectStateContext);
 
   // Expose the Select state to the out-of-tree sub-panel (see Filter comment).
@@ -253,60 +267,61 @@ const FilterInner = (props: FilterInnerProps) => {
           }}
         >
           <ListBox>
-          {filterProps.options.map((option) => {
-            const hasSubContent =
-              !!option.subContent && option.value !== undefined;
-            return (
-              <Fragment key={option.value}>
-                <ListBoxItem
-                  key={option.value}
-                  id={option.value}
-                  textValue={option.label}
-                  className="c__dropdown-menu-item"
-                  data-has-submenu={hasSubContent}
-                  // Carries the option value (the DOM `id` is a react-aria
-                  // generated key) so the keyboard handler can open this row.
-                  data-submenu-value={hasSubContent ? option.value : undefined}
-                  ref={hasSubContent ? getRowRef(option.value!) : undefined}
-                  onMouseEnter={
-                    hasSubContent
-                      ? () => openSub(option.value as string)
-                      : undefined
-                  }
-                  onMouseLeave={hasSubContent ? scheduleClose : undefined}
-                  // Swallow the press in the capture phase so react-aria's Select
-                  // never selects this row (which would close the popover). The
-                  // sub-panel is driven by hover + its own actions instead.
-                  onPointerDownCapture={
-                    hasSubContent
-                      ? (event) => event.stopPropagation()
-                      : undefined
-                  }
-                  onPointerUpCapture={
-                    hasSubContent
-                      ? (event) => event.stopPropagation()
-                      : undefined
-                  }
-                >
-                  {/*
-                   * Use the ListBoxItem render prop for selection: the checkmark
-                   * lives inside the ListBox collection, which react-aria renders
-                   * in a pass without `SelectStateContext`, so reading `state`
-                   * here is unreliable. `isSelected` is provided per item and is
-                   * correct in both controlled and uncontrolled modes.
-                   */}
-                  {({ isSelected }) => (
-                    <MenuItemBody
-                      label={option.render ? option.render() : option.label}
-                      isChecked={isSelected || option.isChecked}
-                      hasSubmenu={hasSubContent}
-                    />
-                  )}
-                </ListBoxItem>
-                {option.showSeparator && <Separator />}
-              </Fragment>
-            );
-          })}
+            {filterProps.options.map((option) => {
+              const hasSubContent =
+                !!option.subContent && option.value !== undefined;
+              return (
+                <Fragment key={option.value}>
+                  <ListBoxItem
+                    key={option.value}
+                    id={option.value}
+                    textValue={option.label}
+                    className="c__dropdown-menu-item"
+                    data-has-submenu={hasSubContent}
+                    // Carries the option value (the DOM `id` is a react-aria
+                    // generated key) so the keyboard handler can open this row.
+                    data-submenu-value={
+                      hasSubContent ? option.value : undefined
+                    }
+                    ref={hasSubContent ? getRowRef(option.value!) : undefined}
+                    onMouseEnter={
+                      hasSubContent
+                        ? () => openSub(option.value as string)
+                        : undefined
+                    }
+                    // Swallow the press in the capture phase so react-aria's Select
+                    // never selects this row (which would close the popover). The
+                    // sub-panel is driven by hover + its own actions instead.
+                    onPointerDownCapture={
+                      hasSubContent
+                        ? (event) => event.stopPropagation()
+                        : undefined
+                    }
+                    onPointerUpCapture={
+                      hasSubContent
+                        ? (event) => event.stopPropagation()
+                        : undefined
+                    }
+                  >
+                    {/*
+                     * Use the ListBoxItem render prop for selection: the checkmark
+                     * lives inside the ListBox collection, which react-aria renders
+                     * in a pass without `SelectStateContext`, so reading `state`
+                     * here is unreliable. `isSelected` is provided per item and is
+                     * correct in both controlled and uncontrolled modes.
+                     */}
+                    {({ isSelected }) => (
+                      <MenuItemBody
+                        label={option.render ? option.render() : option.label}
+                        isChecked={isSelected || option.isChecked}
+                        hasSubmenu={hasSubContent}
+                      />
+                    )}
+                  </ListBoxItem>
+                  {option.showSeparator && <Separator />}
+                </Fragment>
+              );
+            })}
           </ListBox>
         </div>
       </Popover>


### PR DESCRIPTION
## What

The Filter sub-content popover (e.g. the date-range picker) used to close as soon as the pointer left it. It now:

- stays open when the pointer moves away,
- closes only on a click outside,
- and is dismissed when any option is selected.

## Why

Closing on hover-out made the sub-panel hard to reach and use. react-aria disables interact-outside dismissal for non-modal popovers, so the click-outside behavior is handled with a dedicated `pointerdown` listener.

## Notes

- Story updated to commit the date range only once the picker is confirmed.
- e2e coverage added for the three behaviors above.