### PR TITLE
✨(front) add reset row to Filter and SearchFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - ✨(filter) add custom sub-element support to options
 - ✨(help-menu) add legal links and custom options
 - ✨(front) add SmartScroller component
+- ✨(front) add a reset row to Filter
+- ✨(front) add a reset row to SearchFilter and ui revamp
+- ✨(front) align menu item to figma ( mainly smaller )
 
 ## 0.23.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 [UNRELEASED]
 
-### Patch CHanges
+### Patch Changes
 
 - 🐛(front) dismiss filter sub-panel on click outside, not hover out
 - ♻️(front) keep SmartScroller arrows mounted for smooth fades
 - ♻️(front) improve SmartScroller blurry gradient
 - 🐛(front) fix SmartScroller button background
 - 💄(front) refresh the mini file icons
+- ✨(front) add a reset row to Filter
+- ✨(front) add a reset row to SearchFilter
+- ♻️(front) use Icon components for menu item affordances
 
 ## 0.25.0
 

--- a/e2e/filter/filter-reset.spec.tsx
+++ b/e2e/filter/filter-reset.spec.tsx
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { TestResetFilter } from "../helpers/mount-filter";
+
+// The reset row lives *outside* the ListBox (react-aria's CollectionBuilder
+// drops non-collection children), so it is a plain element rather than an
+// `option` — locate it by its label within the dropdown popover.
+const resetRow = (page: import("@playwright/test").Page) =>
+  page.locator(".c__dropdown-menu-item", { hasText: "Reset" });
+
+test.describe("Filter — reset row (showReset)", () => {
+  test("appears only once a value is selected", async ({ mount, page }) => {
+    await mount(<TestResetFilter />);
+    const trigger = page.getByRole("button", { name: /Type/ });
+
+    // Nothing selected yet → no reset row in the open dropdown.
+    await trigger.click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(resetRow(page)).toHaveCount(0);
+
+    // Select an option → the reset row shows on the next open.
+    await page.getByRole("option", { name: "File" }).click();
+    await expect(trigger).toHaveAccessibleName("Type : File");
+
+    await trigger.click();
+    await expect(resetRow(page)).toBeVisible();
+  });
+
+  test("clicking it clears the selection and keeps the menu open", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestResetFilter />);
+    const trigger = page.getByRole("button", { name: /Type/ });
+
+    await trigger.click();
+    await page.getByRole("option", { name: "Folder" }).click();
+    await expect(trigger).toHaveAccessibleName("Type : Folder");
+
+    await trigger.click();
+    await resetRow(page).click();
+
+    // Selection cleared, the reset row hides itself, and — unlike picking an
+    // option — the popover stays open with no checkmark left.
+    await expect(trigger).toHaveAccessibleName("Type");
+    await expect(resetRow(page)).toHaveCount(0);
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.locator(".c__dropdown-menu-item__check")).toHaveCount(0);
+  });
+
+  test("is hidden when showReset is false, even with a selection", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestResetFilter showReset={false} />);
+    const trigger = page.getByRole("button", { name: /Type/ });
+
+    await trigger.click();
+    await page.getByRole("option", { name: "File" }).click();
+    await expect(trigger).toHaveAccessibleName("Type : File");
+
+    await trigger.click();
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(resetRow(page)).toHaveCount(0);
+  });
+});

--- a/e2e/filter/filter-reset.spec.tsx
+++ b/e2e/filter/filter-reset.spec.tsx
@@ -2,10 +2,10 @@ import { test, expect } from "@playwright/experimental-ct-react";
 import { TestResetFilter } from "../helpers/mount-filter";
 
 // The reset row lives *outside* the ListBox (react-aria's CollectionBuilder
-// drops non-collection children), so it is a plain element rather than an
-// `option` — locate it by its label within the dropdown popover.
+// drops non-collection children), so it is a native button rather than an
+// `option` — keyboard operable and located by its accessible name.
 const resetRow = (page: import("@playwright/test").Page) =>
-  page.locator(".c__dropdown-menu-item", { hasText: "Reset" });
+  page.getByRole("button", { name: "Reset" });
 
 test.describe("Filter — reset row (showReset)", () => {
   test("appears only once a value is selected", async ({ mount, page }) => {
@@ -45,6 +45,35 @@ test.describe("Filter — reset row (showReset)", () => {
     await expect(resetRow(page)).toHaveCount(0);
     await expect(page.getByRole("listbox")).toBeVisible();
     await expect(page.locator(".c__dropdown-menu-item__check")).toHaveCount(0);
+  });
+
+  test("is reachable and operable with the keyboard", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestResetFilter />);
+    const trigger = page.getByRole("button", { name: /Type/ });
+
+    await trigger.click();
+    await page.getByRole("option", { name: "File" }).click();
+    await expect(trigger).toHaveAccessibleName("Type : File");
+
+    // Reopen with the keyboard (a mouse click leaves DOM focus outside the
+    // popover in Firefox): react-aria focuses the selected option, and the
+    // reset button precedes the ListBox in the popover, so Shift+Tab reaches it.
+    await trigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "File" }),
+    ).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(resetRow(page)).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await expect(trigger).toHaveAccessibleName("Type");
+    await expect(resetRow(page)).toHaveCount(0);
+    await expect(page.getByRole("listbox")).toBeVisible();
   });
 
   test("is hidden when showReset is false, even with a selection", async ({

--- a/e2e/filter/filter.spec.tsx
+++ b/e2e/filter/filter.spec.tsx
@@ -32,10 +32,11 @@ test.describe("Filter", () => {
 
   test("shows a checkmark on the selected option", async ({ page }) => {
     const trigger = page.getByRole("button", { name: /Updated/ });
+    const check = page.locator(".c__dropdown-menu-item__check");
     await trigger.click();
 
     // Nothing selected yet → no checkmark anywhere.
-    await expect(page.getByText("check", { exact: true })).toHaveCount(0);
+    await expect(check).toHaveCount(0);
 
     await page.getByRole("option", { name: "Today" }).click();
 
@@ -43,10 +44,12 @@ test.describe("Filter", () => {
     await trigger.click();
     const selected = page.getByRole("option", { name: "Today", selected: true });
     await expect(selected).toBeVisible();
-    await expect(selected.getByText("check", { exact: true })).toBeVisible();
+    await expect(
+      selected.locator(".c__dropdown-menu-item__check"),
+    ).toBeVisible();
 
     // The checkmark is exclusive to the selected option.
-    await expect(page.getByText("check", { exact: true })).toHaveCount(1);
+    await expect(check).toHaveCount(1);
   });
 
   test("the Custom option shows a chevron affordance that normal options lack", async ({
@@ -55,11 +58,15 @@ test.describe("Filter", () => {
     await page.getByRole("button", { name: /Updated/ }).click();
 
     await expect(
-      page.getByRole("option", { name: "Custom" }),
-    ).toHaveAccessibleName(/chevron_right/);
+      page
+        .getByRole("option", { name: "Custom" })
+        .locator(".c__dropdown-menu-item__chevron"),
+    ).toBeVisible();
     await expect(
-      page.getByRole("option", { name: "Today" }),
-    ).toHaveAccessibleName("Today");
+      page
+        .getByRole("option", { name: "Today" })
+        .locator(".c__dropdown-menu-item__chevron"),
+    ).toHaveCount(0);
   });
 
   // --- Sub-element (CalendarRange) feature -----------------------------------

--- a/e2e/helpers/mount-filter.tsx
+++ b/e2e/helpers/mount-filter.tsx
@@ -61,3 +61,28 @@ export const TestFilter = () => {
     </CunninghamProvider>
   );
 };
+
+// Minimal Filter used to exercise the built-in reset row (`showReset`). Kept
+// separate from `TestFilter` so there is no external "Reset" button to collide
+// with the reset row's label.
+export const TestResetFilter = ({ showReset }: { showReset?: boolean }) => {
+  const [selected, setSelected] = useState<Key | null>(null);
+
+  const options: FilterOption[] = [
+    { label: "All", value: "all" },
+    { label: "File", value: "file" },
+    { label: "Folder", value: "folder" },
+  ];
+
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <Filter
+        label="Type"
+        options={options}
+        value={selected}
+        onChange={setSelected}
+        showReset={showReset}
+      />
+    </CunninghamProvider>
+  );
+};

--- a/e2e/helpers/mount-search-filter.tsx
+++ b/e2e/helpers/mount-search-filter.tsx
@@ -1,0 +1,93 @@
+import { ReactNode, useState } from "react";
+import { CunninghamProvider } from "../../src/components/Provider/Provider";
+import { SearchFilter } from "../../src/components/search-filter/SearchFilter";
+import { UserSearchFilter } from "../../src/components/search-filter/UserSearchFilter";
+import {
+  SearchFilterItem,
+  UserSearchFilterItem,
+} from "../../src/components/search-filter/types";
+
+// Playwright CT bridges function props as one-way dispatchers whose return
+// value is always `undefined`, so a controlled component like SearchFilter
+// can't be driven from the test file. These helpers run in the browser and
+// build the actual stateful scenario locally, mirroring the stories.
+
+const simpleItems: SearchFilterItem[] = [
+  { id: "apple", label: "Apple" },
+  { id: "banana", label: "Banana" },
+  { id: "cherry", label: "Cherry" },
+];
+
+interface TestSearchFilterProps {
+  /** Forwarded to SearchFilter; defaults to its own default (`true`). */
+  showReset?: boolean;
+  isLoading?: boolean;
+  emptyState?: ReactNode;
+  /** Pre-selects an item so the Reset row is present on first open. */
+  initialSelected?: SearchFilterItem;
+}
+
+export const TestSearchFilter = ({
+  showReset,
+  isLoading,
+  emptyState,
+  initialSelected,
+}: TestSearchFilterProps) => {
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<SearchFilterItem | undefined>(
+    initialSelected,
+  );
+
+  const filtered = simpleItems.filter((item) =>
+    item.label.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <SearchFilter
+        label="Category"
+        activeLabel={selected?.label}
+        searchValue={search}
+        onSearchChange={setSearch}
+        placeholder="Search..."
+        items={filtered}
+        renderItem={(item) => (
+          <div className="c__dropdown-menu-item">{item.label}</div>
+        )}
+        onItemSelect={setSelected}
+        selected={selected}
+        showReset={showReset}
+        isLoading={isLoading}
+        emptyState={emptyState}
+      />
+    </CunninghamProvider>
+  );
+};
+
+const mockUsers: UserSearchFilterItem[] = [
+  { id: "1", label: "Alice Martin", fullName: "Alice Martin" },
+  { id: "2", label: "Bob Dupont", fullName: "Bob Dupont" },
+];
+
+export const TestUserSearchFilter = () => {
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<UserSearchFilterItem | undefined>();
+
+  const filtered = mockUsers.filter((user) =>
+    user.fullName.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <CunninghamProvider currentLocale="en-US">
+      <UserSearchFilter
+        label="Owner"
+        activeLabel={selected?.fullName}
+        searchValue={search}
+        onSearchChange={setSearch}
+        items={filtered}
+        onItemSelect={setSelected}
+        selected={selected}
+      />
+    </CunninghamProvider>
+  );
+};

--- a/e2e/search-filter/search-filter.spec.tsx
+++ b/e2e/search-filter/search-filter.spec.tsx
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import {
+  TestSearchFilter,
+  TestUserSearchFilter,
+} from "../helpers/mount-search-filter";
+
+test.describe("SearchFilter", () => {
+  const triggerName = /Category/;
+
+  // The Reset row lives above the search box and is a plain div (not a
+  // listbox option), so it is located by its text rather than by role.
+  // --- Reset feature (the point of this branch) ----------------------------
+
+  test("shows no Reset row when nothing is selected", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+  });
+
+  test("shows a Reset row once an item is selected", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+    const trigger = page.getByRole("button", { name: triggerName });
+
+    await trigger.click();
+    await page.getByRole("option", { name: "Apple" }).click();
+    await expect(trigger).toHaveAccessibleName("Category : Apple");
+
+    await trigger.click();
+    await expect(page.getByText("Reset", { exact: true })).toBeVisible();
+  });
+
+  test("clicking Reset clears the selection", async ({ mount, page }) => {
+    await mount(<TestSearchFilter />);
+    const trigger = page.getByRole("button", { name: triggerName });
+
+    await trigger.click();
+    await page.getByRole("option", { name: "Apple" }).click();
+    await trigger.click();
+
+    // Reset only clears the selection; it does not close the popover, so the
+    // row vanishes in place and the trigger drops the active value.
+    await page.getByText("Reset", { exact: true }).click();
+
+    await expect(trigger).toHaveAccessibleName("Category");
+    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+  });
+
+  test("showReset={false} hides the Reset row even when selected", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestSearchFilter
+        showReset={false}
+        initialSelected={{ id: "apple", label: "Apple" }}
+      />,
+    );
+    const trigger = page.getByRole("button", { name: triggerName });
+    await expect(trigger).toHaveAccessibleName("Category : Apple");
+
+    await trigger.click();
+
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+  });
+
+  // --- Core behavior --------------------------------------------------------
+
+  test("opens the dropdown with a search input and all options", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+
+    await expect(page.getByRole("listbox")).toBeVisible();
+    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    for (const name of ["Apple", "Banana", "Cherry"]) {
+      await expect(page.getByRole("option", { name })).toBeVisible();
+    }
+  });
+
+  test("selecting an option updates the trigger, closes the popover, and clears the search", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+    const trigger = page.getByRole("button", { name: triggerName });
+
+    await trigger.click();
+    await page.getByPlaceholder("Search...").fill("Ap");
+    await page.getByRole("option", { name: "Apple" }).click();
+
+    await expect(page.getByRole("listbox")).not.toBeVisible();
+    await expect(trigger).toHaveAccessibleName("Category : Apple");
+
+    // Reopening shows the search box has been reset.
+    await trigger.click();
+    await expect(page.getByPlaceholder("Search...")).toHaveValue("");
+  });
+
+  test("typing in the search box filters the options", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+    await page.getByPlaceholder("Search...").fill("ban");
+
+    await expect(page.getByRole("option", { name: "Banana" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "Apple" })).toHaveCount(0);
+    await expect(page.getByRole("option", { name: "Cherry" })).toHaveCount(0);
+  });
+
+  test("shows a spinner and no options while loading", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter isLoading />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+
+    // The loading row is itself a listbox option, so assert the data options
+    // are suppressed rather than expecting zero options overall.
+    await expect(page.locator(".c__search-filter__loading")).toBeVisible();
+    await expect(page.getByRole("option", { name: "Apple" })).toHaveCount(0);
+  });
+
+  test("renders the empty state when no option matches", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter emptyState="No results" />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+    await page.getByPlaceholder("Search...").fill("zzz");
+
+    // The empty-state row is itself a listbox option, so assert the data
+    // options are gone rather than expecting zero options overall.
+    await expect(page.getByText("No results")).toBeVisible();
+    await expect(page.getByRole("option", { name: "Banana" })).toHaveCount(0);
+  });
+
+  test("Escape closes the popover and restores focus to the trigger", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+    const trigger = page.getByRole("button", { name: triggerName });
+
+    await trigger.click();
+    const input = page.getByPlaceholder("Search...");
+    await expect(input).toBeVisible();
+    await input.focus();
+
+    await input.press("Escape");
+
+    await expect(page.getByRole("listbox")).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  });
+});
+
+test.describe("UserSearchFilter", () => {
+  test("renders each user's full name as an option", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestUserSearchFilter />);
+
+    await page.getByRole("button", { name: /Owner/ }).click();
+
+    await expect(
+      page.getByRole("option", { name: "Alice Martin" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("option", { name: "Bob Dupont" }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/search-filter/search-filter.spec.tsx
+++ b/e2e/search-filter/search-filter.spec.tsx
@@ -149,6 +149,35 @@ test.describe("SearchFilter", () => {
     await expect(page.getByRole("option", { name: "Cherry" })).toHaveCount(0);
   });
 
+  test("keyboard navigation among options is visibly highlighted", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TestSearchFilter />);
+
+    await page.getByRole("button", { name: triggerName }).click();
+    await expect(page.getByPlaceholder("Search...")).toBeFocused();
+
+    // ArrowDown moves focus from the input into the list…
+    await page.keyboard.press("ArrowDown");
+    const apple = page.getByRole("option", { name: "Apple" });
+    await expect(apple).toBeFocused();
+
+    // …and the focused option must be visually highlighted: react-aria sets
+    // `data-focused` on the ListBoxItem itself, not on the inner
+    // `.c__dropdown-menu-item` rendered by `renderItem`.
+    await expect(apple).toHaveAttribute("data-focused", "true");
+    const background = await apple.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    expect(background).not.toBe("rgba(0, 0, 0, 0)");
+
+    // Arrow keys move the highlight between options.
+    await page.keyboard.press("ArrowDown");
+    await expect(page.getByRole("option", { name: "Banana" })).toBeFocused();
+    await expect(apple).not.toHaveAttribute("data-focused", "true");
+  });
+
   test("shows a spinner and no options while loading", async ({
     mount,
     page,

--- a/e2e/search-filter/search-filter.spec.tsx
+++ b/e2e/search-filter/search-filter.spec.tsx
@@ -7,8 +7,11 @@ import {
 test.describe("SearchFilter", () => {
   const triggerName = /Category/;
 
-  // The Reset row lives above the search box and is a plain div (not a
-  // listbox option), so it is located by its text rather than by role.
+  // The Reset row lives above the search box, outside the listbox, and is
+  // rendered as a native button so it is keyboard operable.
+  const resetButton = (page: import("@playwright/test").Page) =>
+    page.getByRole("button", { name: "Reset" });
+
   // --- Reset feature (the point of this branch) ----------------------------
 
   test("shows no Reset row when nothing is selected", async ({
@@ -20,7 +23,7 @@ test.describe("SearchFilter", () => {
     await page.getByRole("button", { name: triggerName }).click();
 
     await expect(page.getByRole("listbox")).toBeVisible();
-    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+    await expect(resetButton(page)).toHaveCount(0);
   });
 
   test("shows a Reset row once an item is selected", async ({
@@ -35,7 +38,7 @@ test.describe("SearchFilter", () => {
     await expect(trigger).toHaveAccessibleName("Category : Apple");
 
     await trigger.click();
-    await expect(page.getByText("Reset", { exact: true })).toBeVisible();
+    await expect(resetButton(page)).toBeVisible();
   });
 
   test("clicking Reset clears the selection", async ({ mount, page }) => {
@@ -48,10 +51,33 @@ test.describe("SearchFilter", () => {
 
     // Reset only clears the selection; it does not close the popover, so the
     // row vanishes in place and the trigger drops the active value.
-    await page.getByText("Reset", { exact: true }).click();
+    await resetButton(page).click();
 
     await expect(trigger).toHaveAccessibleName("Category");
-    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+    await expect(resetButton(page)).toHaveCount(0);
+  });
+
+  test("Reset is reachable and operable with the keyboard", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <TestSearchFilter
+        initialSelected={{ id: "apple", label: "Apple" }}
+      />,
+    );
+    const trigger = page.getByRole("button", { name: triggerName });
+
+    await trigger.click();
+    await expect(page.getByPlaceholder("Search...")).toBeFocused();
+
+    // The Reset button precedes the search box in the popover.
+    await page.keyboard.press("Shift+Tab");
+    await expect(resetButton(page)).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await expect(trigger).toHaveAccessibleName("Category");
+    await expect(resetButton(page)).toHaveCount(0);
   });
 
   test("showReset={false} hides the Reset row even when selected", async ({
@@ -70,7 +96,7 @@ test.describe("SearchFilter", () => {
     await trigger.click();
 
     await expect(page.getByRole("listbox")).toBeVisible();
-    await expect(page.getByText("Reset", { exact: true })).toHaveCount(0);
+    await expect(resetButton(page)).toHaveCount(0);
   });
 
   // --- Core behavior --------------------------------------------------------

--- a/src/components/dropdown-menu/index.scss
+++ b/src/components/dropdown-menu/index.scss
@@ -9,6 +9,10 @@
   outline: none;
 }
 
+.react-aria-ListBox {
+  outline: none;
+}
+
 .c__dropdown-menu {
   background-color: var(--c--contextuals--background--surface--primary);
   z-index: 1000;
@@ -19,7 +23,7 @@
   min-width: 150px;
   box-sizing: border-box;
   outline: none;
-  border-radius: var(--c--globals--spacings--3xs, 4px);
+  border-radius: 8px;
   border: 1px solid var(--c--contextuals--border--surface--primary);
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 145, 0.1);
 
@@ -42,10 +46,9 @@
 
 .c__dropdown-menu-item {
   display: flex;
-  gap: var(--c--globals--spacings--base, 16px);
-  padding: 8px 16px;
+  gap: 8px;
+  padding: 8px 8px;
   border-bottom: 1px solid transparent;
-  padding-right: 24px;
 
   outline: none;
   cursor: pointer;
@@ -60,8 +63,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
     color: var(--c--contextuals--content--semantic--neutral--tertiary);
   }
 
@@ -114,15 +115,6 @@
     .c__dropdown-menu-item__label-subtext {
       color: var(--c--contextuals--content--semantic--disabled--primary);
     }
-  }
-
-  .material-icons {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    font-size: 20px;
   }
 
   .checked {

--- a/src/components/dropdown-menu/index.scss
+++ b/src/components/dropdown-menu/index.scss
@@ -44,7 +44,8 @@
   font-size: var(--c--globals--font--sizes--xs, 0.75rem);
 }
 
-.c__dropdown-menu-item {
+.c__dropdown-menu-item,
+button.c__dropdown-menu-item {
   display: flex;
   gap: 8px;
   padding: 8px 8px;
@@ -119,6 +120,23 @@
 
   .checked {
     margin-left: var(--c--globals--spacings--md, 1.5rem);
+  }
+}
+
+// Reset rows are native buttons (keyboard operable, unlike ListBox items they
+// get no react-aria handling): neutralize the UA button styles and mirror the
+// `[data-focused]` background on keyboard focus.
+button.c__dropdown-menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+
+  &:focus-visible {
+    background: var(
+      --c--contextuals--background--semantic--contextual--primary
+    );
   }
 }
 

--- a/src/components/filter/Filter.stories.tsx
+++ b/src/components/filter/Filter.stories.tsx
@@ -20,6 +20,9 @@ import { DateValue } from "@internationalized/date";
  * - **Custom option rendering.** Each option can supply a `render` function to
  *   display icons or richer content instead of a plain label.
  * - **Separators.** Set `showSeparator` on an option to draw a divider after it.
+ * - **Built-in reset.** Once a value is selected, a "Reset" row appears above the
+ *   options to clear the selection. It is enabled by default; pass
+ *   `showReset={false}` to hide it (e.g. when a value must always be selected).
  * - **Sub-panels.** An option can expose a `subContent` panel (e.g. a date-range
  *   picker) that opens on hover, with `select` / `close` helpers to drive the
  *   parent selection.
@@ -50,6 +53,7 @@ import { DateValue } from "@internationalized/date";
  * |------|------|-------------|
  * | `label` | `string` | Text shown on the trigger button; combined with the selected option's label once a value is picked |
  * | `options` | `FilterOption[]` | The selectable entries |
+ * | `showReset` | `boolean?` | Show a built-in "Reset" row (with an undo icon) above the options that clears the selection. Defaults to `true`; only visible while a value is selected |
  * | `defaultValue` | `Key \| null?` | Initial selection in uncontrolled mode |
  * | `value` | `Key \| null?` | Selected value in controlled mode |
  * | `onChange` | `(key: Key \| null) => void` | Fires when the user picks an option |
@@ -83,6 +87,11 @@ const meta: Meta<typeof Filter> = {
     options: {
       description: "The selectable entries",
       control: false,
+    },
+    showReset: {
+      description:
+        'Show a built-in "Reset" row above the options that clears the selection; visible only while a value is selected',
+      control: "boolean",
     },
     defaultValue: {
       description: "Initial selection in uncontrolled mode",
@@ -179,6 +188,33 @@ export const UncontrolledWithDefault: Story = {
     label: "Type",
     defaultValue: "folder",
     options: OPTIONS,
+  },
+};
+
+/**
+ * A value is pre-selected, so opening the dropdown reveals the built-in **Reset**
+ * row above the options. Clicking it clears the selection (the trigger falls back
+ * to just the `label`) without leaving the menu. The row is shown by default and
+ * only while something is selected.
+ */
+export const WithReset: Story = {
+  args: {
+    label: "Type",
+    defaultValue: "file",
+    options: OPTIONS,
+  },
+};
+
+/**
+ * Passing `showReset={false}` hides the reset row entirely — useful when the
+ * filter should always keep a value selected and clearing it makes no sense.
+ */
+export const WithoutReset: Story = {
+  args: {
+    label: "Type",
+    defaultValue: "file",
+    options: OPTIONS,
+    showReset: false,
   },
 };
 

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -21,13 +21,11 @@ import {
   Separator,
 } from "react-aria-components";
 
-import { Option, useCunningham } from "@gouvfr-lasuite/cunningham-react";
+import { Option } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 
 import { MenuItemBody } from "../menu/MenuItemBody";
-import { IconSize } from "../icon";
-import { Undo } from ":/icons";
-import { HorizontalSeparator } from "../separator";
+import { FilterResetRow } from "./FilterResetRow";
 
 export type FilterSubContentHelpers = {
   /** Selects this option (sets the Filter's selected key to the option value). */
@@ -209,7 +207,6 @@ const FilterInner = (props: FilterInnerProps) => {
     ...filterProps
   } = props;
   const state = useContext(SelectStateContext);
-  const { t } = useCunningham();
 
   // Expose the Select state to the out-of-tree sub-panel (see Filter comment).
   selectStateRef.current = state ?? null;
@@ -266,18 +263,7 @@ const FilterInner = (props: FilterInnerProps) => {
          * `state` from SelectStateContext is available) makes it show reliably.
          */}
         {showReset && state?.value && (
-          <>
-            <div
-              className="c__dropdown-menu-item"
-              onClick={() => state?.setValue(null)}
-            >
-              <MenuItemBody
-                icon={<Undo size={IconSize.SMALL} />}
-                label={t("components.searchFilter.reset")}
-              />
-            </div>
-            <HorizontalSeparator withPadding={false} />
-          </>
+          <FilterResetRow onReset={() => state?.setValue(null)} />
         )}
         <div
           onKeyDownCapture={(event) => {

--- a/src/components/filter/Filter.tsx
+++ b/src/components/filter/Filter.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import {
   Button,
+  Key,
   Label,
   ListBox,
   ListBoxItem,
@@ -20,10 +21,13 @@ import {
   Separator,
 } from "react-aria-components";
 
-import { Option } from "@gouvfr-lasuite/cunningham-react";
+import { Option, useCunningham } from "@gouvfr-lasuite/cunningham-react";
 import clsx from "clsx";
 
 import { MenuItemBody } from "../menu/MenuItemBody";
+import { IconSize } from "../icon";
+import { Undo } from ":/icons";
+import { HorizontalSeparator } from "../separator";
 
 export type FilterSubContentHelpers = {
   /** Selects this option (sets the Filter's selected key to the option value). */
@@ -45,11 +49,12 @@ export type FilterOption = Option & {
 export type FilterProps = {
   label: string;
   options: FilterOption[];
+  showReset?: boolean;
 } & SelectProps;
 
 /** Minimal slice of react-aria's SelectState used to drive custom selection. */
 type SelectStateLike = {
-  setValue: (value: string) => void;
+  setValue: (value: Key | null) => void;
   close: () => void;
 };
 
@@ -196,8 +201,15 @@ type FilterInnerProps = FilterProps & {
 };
 
 const FilterInner = (props: FilterInnerProps) => {
-  const { getRowRef, openSub, selectStateRef, ...filterProps } = props;
+  const {
+    getRowRef,
+    openSub,
+    selectStateRef,
+    showReset = true,
+    ...filterProps
+  } = props;
   const state = useContext(SelectStateContext);
+  const { t } = useCunningham();
 
   // Expose the Select state to the out-of-tree sub-panel (see Filter comment).
   selectStateRef.current = state ?? null;
@@ -246,6 +258,27 @@ const FilterInner = (props: FilterInnerProps) => {
          * sub-content row opens its panel and moves focus into it instead of
          * selecting the row.
          */}
+        {/*
+         * The reset row is rendered *outside* the ListBox on purpose: react-aria
+         * runs ListBox children through its CollectionBuilder, which only keeps
+         * recognized collection nodes (ListBoxItem, Section, …) and silently drops
+         * plain DOM like this <div>. Rendering it here (a normal render pass where
+         * `state` from SelectStateContext is available) makes it show reliably.
+         */}
+        {showReset && state?.value && (
+          <>
+            <div
+              className="c__dropdown-menu-item"
+              onClick={() => state?.setValue(null)}
+            >
+              <MenuItemBody
+                icon={<Undo size={IconSize.SMALL} />}
+                label={t("components.searchFilter.reset")}
+              />
+            </div>
+            <HorizontalSeparator withPadding={false} />
+          </>
+        )}
         <div
           onKeyDownCapture={(event) => {
             if (

--- a/src/components/filter/FilterResetRow.tsx
+++ b/src/components/filter/FilterResetRow.tsx
@@ -1,0 +1,36 @@
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
+
+import { MenuItemBody } from "../menu/MenuItemBody";
+import { IconSize } from "../icon";
+import { Undo } from ":/icons";
+import { HorizontalSeparator } from "../separator";
+
+export type FilterResetRowProps = {
+  onReset: () => void;
+};
+
+/**
+ * Reset row shared by Filter and SearchFilter. Rendered as a native button so
+ * it is keyboard focusable and activatable (Enter/Space) — the row lives
+ * outside the ListBox, so it gets none of react-aria's listbox keyboard
+ * handling.
+ */
+export const FilterResetRow = ({ onReset }: FilterResetRowProps) => {
+  const { t } = useCunningham();
+
+  return (
+    <>
+      <button
+        type="button"
+        className="c__dropdown-menu-item"
+        onClick={onReset}
+      >
+        <MenuItemBody
+          icon={<Undo size={IconSize.SMALL} />}
+          label={t("components.searchFilter.reset")}
+        />
+      </button>
+      <HorizontalSeparator withPadding={false} />
+    </>
+  );
+};

--- a/src/components/menu/MenuItemBody.stories.tsx
+++ b/src/components/menu/MenuItemBody.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { ReactNode } from "react";
 import { MenuItemBody } from "./MenuItemBody";
+import { Icon, IconSize } from "../icon";
 
 /**
  * `MenuItemBody` is the presentational inner content shared by every menu row:
@@ -62,13 +63,15 @@ const MenuRow = ({
   danger?: boolean;
 }) => (
   <div
-    className={`c__dropdown-menu-item${danger ? " c__dropdown-menu-item--danger" : ""}`}
+    className={`c__dropdown-menu-item${
+      danger ? " c__dropdown-menu-item--danger" : ""
+    }`}
   >
     {children}
   </div>
 );
 
-const icon = (name: string) => <span className="material-icons">{name}</span>;
+const icon = (name: string) => <Icon name={name} size={IconSize.SMALL} />;
 
 export const Default: Story = {
   args: {
@@ -159,7 +162,11 @@ export const Gallery: Story = {
         <MenuItemBody icon={icon("visibility")} label="Viewer" isChecked />
       </MenuRow>
       <MenuRow>
-        <MenuItemBody icon={icon("drive_file_move")} label="Move to" hasSubmenu />
+        <MenuItemBody
+          icon={icon("drive_file_move")}
+          label="Move to"
+          hasSubmenu
+        />
       </MenuRow>
       <MenuRow>
         <MenuItemBody label="Rename" />

--- a/src/components/menu/MenuItemBody.tsx
+++ b/src/components/menu/MenuItemBody.tsx
@@ -1,4 +1,6 @@
+import { Checkmark2, ChevronRight } from ":/icons";
 import { ReactNode } from "react";
+import { IconSize } from "../icon";
 
 export type MenuItemBodyProps = {
   icon?: ReactNode;
@@ -32,11 +34,15 @@ export const MenuItemBody = ({
       )}
     </div>
     {hasSubmenu ? (
-      <span className="material-icons c__dropdown-menu-item__chevron">
-        chevron_right
-      </span>
+      <ChevronRight
+        size={IconSize.SMALL}
+        className="c__dropdown-menu-item__chevron"
+      />
     ) : isChecked ? (
-      <span className="material-icons checked">check</span>
+      <Checkmark2
+        size={IconSize.SMALL}
+        className="c__dropdown-menu-item__check"
+      />
     ) : null}
   </>
 );

--- a/src/components/search-filter/SearchFilter.mdx
+++ b/src/components/search-filter/SearchFilter.mdx
@@ -1,0 +1,107 @@
+import { Meta, Canvas, ArgTypes } from "@storybook/blocks";
+import * as SearchFilterStories from "./search-filter.stories";
+
+<Meta of={SearchFilterStories} name="Docs" />
+
+# SearchFilter
+
+`SearchFilter` is a filter button that opens a popover combining a search input with a scrollable list of results. It is designed for the "filter by X" chips found in toolbars: the trigger shows the filter label, and once a value is picked it reads `Label : value` and switches to an active style.
+
+The component is **fully controlled**: it owns the popover and keyboard interactions, but you own the search string and the list of items. This means the actual filtering (or remote fetching, debouncing, pagination…) happens on your side — `SearchFilter` just renders what you pass through `items`.
+
+All labels (such as the "Reset" entry) are translated via Cunningham (`useCunningham`), so the component must live under a `CunninghamProvider`.
+
+## Usage
+
+```tsx
+import { SearchFilter } from "@gouvfr-lasuite/ui-kit";
+import { MenuItemBody } from "@gouvfr-lasuite/ui-kit";
+
+const [search, setSearch] = useState("");
+const [selected, setSelected] = useState<SearchFilterItem>();
+
+const filtered = items.filter((item) =>
+  item.label.toLowerCase().includes(search.toLowerCase()),
+);
+
+<SearchFilter
+  label="Category"
+  activeLabel={selected?.label}
+  searchValue={search}
+  onSearchChange={setSearch}
+  placeholder="Search..."
+  items={filtered}
+  renderItem={(item) => (
+    <div className="c__dropdown-menu-item">
+      <MenuItemBody label={item.label} />
+    </div>
+  )}
+  onItemSelect={setSelected}
+  selected={selected}
+/>;
+```
+
+The styles are bundled in `@gouvfr-lasuite/ui-kit/style`, so make sure it is imported once in your app.
+
+<Canvas of={SearchFilterStories.Basic} />
+
+## Behaviour
+
+- Clicking the trigger toggles the popover. When it opens, focus moves to the search input automatically.
+- Typing calls `onSearchChange`; you decide how (and whether) the results change. Nothing is filtered internally.
+- Selecting an item calls `onItemSelect(item)`, clears the search, and closes the popover. The trigger then shows `label : activeLabel` and gains the active style.
+- Keyboard: `ArrowDown` from the input moves focus into the results list, `Escape` closes the popover and returns focus to the trigger. The list itself is a fully accessible `ListBox` (react-aria).
+
+## Controlled state
+
+There are three independent pieces of controlled state, all optional except `onSearchChange`:
+
+- **Search** — `searchValue` / `onSearchChange`. Required wiring; drives the input.
+- **Selection** — `selected` / `onItemSelect`. Pass the currently selected item back as `selected` so the component can render the reset entry.
+- **Open state** — `isOpen` / `onOpenChange`. Omit both to let the component manage its own open/close.
+
+The active (highlighted) state of the trigger is derived from `activeLabel` by default, or you can force it with `isActive`.
+
+## Reset
+
+When `selected` is set and `showReset` is `true` (the default), a "Reset" entry is prepended to the popover. Clicking it calls `onItemSelect(undefined)`, letting the consumer clear the selection. Pass `showReset={false}` to hide it.
+
+## Loading and empty states
+
+While `isLoading` is `true`, a spinner replaces the list — useful for async/remote search. When the search resolves to no results, pass an `emptyState` node to show instead of an empty list.
+
+<Canvas of={SearchFilterStories.Loading} />
+
+<Canvas of={SearchFilterStories.Empty} />
+
+## Props
+
+<ArgTypes of={SearchFilterStories} />
+
+## UserSearchFilter
+
+`UserSearchFilter` is a thin wrapper around `SearchFilter` preconfigured to display people. It renders each row with a [UserAvatar](?path=/docs/components-useravatar--docs) and the user's `fullName`, and defaults the placeholder to "Search for a name", so you only provide the data.
+
+```tsx
+import { UserSearchFilter } from "@gouvfr-lasuite/ui-kit";
+
+<UserSearchFilter
+  label="Owner"
+  activeLabel={selected?.fullName}
+  searchValue={search}
+  onSearchChange={setSearch}
+  items={filteredUsers}
+  onItemSelect={setSelected}
+  selected={selected}
+/>;
+```
+
+Its items extend `SearchFilterItem` with a required `fullName` and an optional `email`. It accepts every `SearchFilter` prop except `renderItem`, which it supplies itself.
+
+<Canvas of={SearchFilterStories.UserSearch} />
+
+### Async user search
+
+A typical remote search debounces the input, shows the loading spinner while fetching, and renders an `emptyState` when nothing matches:
+
+<Canvas of={SearchFilterStories.ManyUsers} />

--- a/src/components/search-filter/SearchFilter.tsx
+++ b/src/components/search-filter/SearchFilter.tsx
@@ -4,6 +4,10 @@ import clsx from "clsx";
 import { HorizontalSeparator } from ":/components/separator/HorizontalSeparator";
 import { Spinner } from ":/components/loader/Spinner";
 import { SearchFilterItem, SearchFilterProps } from "./types";
+import { MenuItemBody } from "../menu/MenuItemBody";
+import { Undo, Zoom } from ":/icons";
+import { IconSize } from "../icon";
+import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
   props: SearchFilterProps<T>,
@@ -22,8 +26,11 @@ export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
     emptyState,
     isOpen: controlledIsOpen,
     onOpenChange,
+    showReset = true,
+    selected,
   } = props;
 
+  const { t } = useCunningham();
   const id = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -101,10 +108,22 @@ export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
         className="c__dropdown-menu c__search-filter__popover"
         style={{ marginTop: "0px" }}
       >
+        {showReset && selected && (
+          <>
+            <div
+              className="c__dropdown-menu-item"
+              onClick={() => onItemSelect?.(undefined)}
+            >
+              <MenuItemBody
+                icon={<Undo size={IconSize.SMALL} />}
+                label={t("components.searchFilter.reset")}
+              />
+            </div>
+            <HorizontalSeparator withPadding={false} />
+          </>
+        )}
         <div className="c__search-filter__search">
-          <span className="material-icons" aria-hidden="true">
-            search
-          </span>
+          <Zoom size={IconSize.SMALL} />
           <input
             ref={inputRef}
             type="text"
@@ -129,12 +148,20 @@ export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
           }}
         >
           {isLoading && (
-            <ListBoxItem id="__loading" className="c__search-filter__loading" textValue="Loading">
+            <ListBoxItem
+              id="__loading"
+              className="c__search-filter__loading"
+              textValue="Loading"
+            >
               <Spinner />
             </ListBoxItem>
           )}
           {!isLoading && items.length === 0 && emptyState && (
-            <ListBoxItem id="__empty" className="c__search-filter__empty" textValue="Empty">
+            <ListBoxItem
+              id="__empty"
+              className="c__search-filter__empty"
+              textValue="Empty"
+            >
               {emptyState}
             </ListBoxItem>
           )}

--- a/src/components/search-filter/SearchFilter.tsx
+++ b/src/components/search-filter/SearchFilter.tsx
@@ -4,10 +4,9 @@ import clsx from "clsx";
 import { HorizontalSeparator } from ":/components/separator/HorizontalSeparator";
 import { Spinner } from ":/components/loader/Spinner";
 import { SearchFilterItem, SearchFilterProps } from "./types";
-import { MenuItemBody } from "../menu/MenuItemBody";
-import { Undo, Zoom } from ":/icons";
+import { FilterResetRow } from "../filter/FilterResetRow";
+import { Zoom } from ":/icons";
 import { IconSize } from "../icon";
-import { useCunningham } from "@gouvfr-lasuite/cunningham-react";
 
 export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
   props: SearchFilterProps<T>,
@@ -30,7 +29,6 @@ export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
     selected,
   } = props;
 
-  const { t } = useCunningham();
   const id = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -109,18 +107,7 @@ export const SearchFilter = <T extends SearchFilterItem = SearchFilterItem>(
         style={{ marginTop: "0px" }}
       >
         {showReset && selected && (
-          <>
-            <div
-              className="c__dropdown-menu-item"
-              onClick={() => onItemSelect?.(undefined)}
-            >
-              <MenuItemBody
-                icon={<Undo size={IconSize.SMALL} />}
-                label={t("components.searchFilter.reset")}
-              />
-            </div>
-            <HorizontalSeparator withPadding={false} />
-          </>
+          <FilterResetRow onReset={() => onItemSelect?.(undefined)} />
         )}
         <div className="c__search-filter__search">
           <Zoom size={IconSize.SMALL} />

--- a/src/components/search-filter/UserSearchFilter.tsx
+++ b/src/components/search-filter/UserSearchFilter.tsx
@@ -1,6 +1,7 @@
 import { UserAvatar } from ":/components/users/avatar/UserAvatar";
 import { SearchFilter } from "./SearchFilter";
 import { UserSearchFilterItem, UserSearchFilterProps } from "./types";
+import { MenuItemBody } from "../menu/MenuItemBody";
 
 export const UserSearchFilter = (props: UserSearchFilterProps) => {
   return (
@@ -8,9 +9,11 @@ export const UserSearchFilter = (props: UserSearchFilterProps) => {
       {...props}
       placeholder={props.placeholder ?? "Search for a name"}
       renderItem={(item) => (
-        <div className="c__search-filter__user-row">
-          <UserAvatar fullName={item.fullName} size="small" />
-          <span>{item.fullName}</span>
+        <div className="c__dropdown-menu-item">
+          <MenuItemBody
+            label={item.fullName}
+            icon={<UserAvatar fullName={item.fullName} size="xsmall" />}
+          />
         </div>
       )}
     />

--- a/src/components/search-filter/index.scss
+++ b/src/components/search-filter/index.scss
@@ -8,13 +8,8 @@
     display: flex;
     align-items: center;
     gap: var(--c--globals--spacings--xxs, 6px);
-    min-height: 40px;
-    padding: var(--c--globals--spacings--xxs, 6px) var(--c--globals--spacings--xs, 8px);
-
-    .material-icons {
-      font-size: 24px;
-      color: var(--c--contextuals--content--semantic--neutral--tertiary);
-    }
+    height: 36px;
+    padding: 0 var(--c--globals--spacings--xs, 8px);
 
     input {
       flex: 1;
@@ -38,24 +33,13 @@
   }
 
   &__item {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    padding: 8px 16px;
-    min-height: 40px;
+    min-height: 32px;
     cursor: pointer;
     font-size: var(--c--globals--font--sizes--sm, 0.875rem);
     font-weight: 500;
     color: var(--c--contextuals--content--semantic--neutral--primary);
     box-sizing: border-box;
     outline: none;
-
-    &:hover,
-    &:focus-visible {
-      background: var(
-        --c--contextuals--background--semantic--contextual--primary
-      );
-    }
   }
 
   &__user-row {
@@ -69,7 +53,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 16px;
+    padding: 8px;
     color: var(--c--contextuals--content--semantic--neutral--tertiary);
     font-size: var(--c--globals--font--sizes--sm, 0.875rem);
   }

--- a/src/components/search-filter/index.scss
+++ b/src/components/search-filter/index.scss
@@ -41,6 +41,15 @@
     color: var(--c--contextuals--content--semantic--neutral--primary);
     box-sizing: border-box;
     outline: none;
+
+    // react-aria sets `data-focused` on the ListBoxItem itself; consumers
+    // render `.c__dropdown-menu-item` *inside* it, so its `[data-focused]`
+    // style never matches and keyboard navigation was invisible.
+    &[data-focused] {
+      background: var(
+        --c--contextuals--background--semantic--contextual--primary
+      );
+    }
   }
 
   &__user-row {

--- a/src/components/search-filter/index.scss
+++ b/src/components/search-filter/index.scss
@@ -10,6 +10,7 @@
     gap: var(--c--globals--spacings--xxs, 6px);
     height: 36px;
     padding: 0 var(--c--globals--spacings--xs, 8px);
+    color: var(--c--contextuals--content--semantic--neutral--secondary);
 
     input {
       flex: 1;

--- a/src/components/search-filter/search-filter.stories.tsx
+++ b/src/components/search-filter/search-filter.stories.tsx
@@ -4,9 +4,89 @@ import { CunninghamProvider } from ":/components/Provider/Provider";
 import { SearchFilter } from "./SearchFilter";
 import { UserSearchFilter } from "./UserSearchFilter";
 import { SearchFilterItem, UserSearchFilterItem } from "./types";
+import { MenuItemBody } from "../menu";
 
-const meta: Meta = {
+const meta: Meta<typeof SearchFilter> = {
   title: "Components/SearchFilter",
+  component: SearchFilter,
+  argTypes: {
+    label: {
+      description: "Text shown on the trigger button.",
+      table: { type: { summary: "string" } },
+    },
+    activeLabel: {
+      description:
+        "Selected value; renders as `label : activeLabel` and marks the " +
+        "trigger active.",
+      table: { type: { summary: "string" } },
+    },
+    isActive: {
+      description: "Force the active style independently of `activeLabel`.",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "!!activeLabel" },
+      },
+    },
+    searchValue: {
+      description: "Controlled value of the search input.",
+      table: { type: { summary: "string" }, defaultValue: { summary: '""' } },
+    },
+    onSearchChange: {
+      description: "Called on every input change. Required.",
+      table: { type: { summary: "(value: string) => void" } },
+    },
+    placeholder: {
+      description: "Placeholder / accessible label for the search input.",
+      table: { type: { summary: "string" } },
+    },
+    items: {
+      description: "Items to render in the list (already filtered by you).",
+      control: false,
+      table: { type: { summary: "T[]" } },
+    },
+    renderItem: {
+      description: "Renders a single result row.",
+      control: false,
+      table: { type: { summary: "(item: T) => ReactNode" } },
+    },
+    onItemSelect: {
+      description: "Called with the picked item, or `undefined` when reset.",
+      table: { type: { summary: "(item?: T) => void" } },
+    },
+    selected: {
+      description: "Currently selected item; enables the reset entry.",
+      control: false,
+      table: { type: { summary: "T" } },
+    },
+    isLoading: {
+      description: "Shows a spinner instead of the list.",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
+    },
+    emptyState: {
+      description: "Shown when `items` is empty and not loading.",
+      control: false,
+      table: { type: { summary: "ReactNode" } },
+    },
+    isOpen: {
+      description: "Controls the popover open state.",
+      table: { type: { summary: "boolean" } },
+    },
+    onOpenChange: {
+      description: "Called when the popover opens or closes.",
+      table: { type: { summary: "(isOpen: boolean) => void" } },
+    },
+    showReset: {
+      description:
+        "Whether to show the reset entry when an item is selected.",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <CunninghamProvider>
@@ -30,7 +110,7 @@ export const Basic: StoryObj = {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [search, setSearch] = useState("");
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string | undefined>();
+    const [selected, setSelected] = useState<SearchFilterItem>();
 
     const filtered = simpleItems.filter((item) =>
       item.label.toLowerCase().includes(search.toLowerCase()),
@@ -39,15 +119,20 @@ export const Basic: StoryObj = {
     return (
       <SearchFilter
         label="Category"
-        activeLabel={selected}
+        activeLabel={selected?.label}
         searchValue={search}
         onSearchChange={setSearch}
         placeholder="Search..."
         items={filtered}
-        renderItem={(item) => <span>{item.label}</span>}
+        renderItem={(item) => (
+          <div className="c__dropdown-menu-item">
+            <MenuItemBody label={item.label} />
+          </div>
+        )}
         onItemSelect={(item) => {
-          setSelected(item.label);
+          setSelected(item);
         }}
+        selected={selected}
       />
     );
   },
@@ -89,7 +174,7 @@ export const UserSearch: StoryObj = {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [search, setSearch] = useState("");
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string | undefined>();
+    const [selected, setSelected] = useState<UserSearchFilterItem>();
 
     const filtered = mockUsers.filter((user) =>
       user.fullName.toLowerCase().includes(search.toLowerCase()),
@@ -98,13 +183,14 @@ export const UserSearch: StoryObj = {
     return (
       <UserSearchFilter
         label="Owner"
-        activeLabel={selected}
+        activeLabel={selected?.fullName}
         searchValue={search}
         onSearchChange={setSearch}
         items={filtered}
         onItemSelect={(user) => {
-          setSelected(user.fullName);
+          setSelected(user);
         }}
+        selected={selected}
       />
     );
   },
@@ -132,7 +218,7 @@ export const ManyUsers: StoryObj = {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [search, setSearch] = useState("");
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string | undefined>();
+    const [selected, setSelected] = useState<UserSearchFilterItem>();
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [isLoading, setIsLoading] = useState(false);
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -166,15 +252,16 @@ export const ManyUsers: StoryObj = {
     return (
       <UserSearchFilter
         label="Owner"
-        activeLabel={selected}
+        activeLabel={selected?.fullName}
         searchValue={search}
         onSearchChange={setSearch}
         items={results}
         isLoading={isLoading}
         emptyState="No users found"
         onItemSelect={(user) => {
-          setSelected(user.fullName);
+          setSelected(user);
         }}
+        selected={selected}
       />
     );
   },

--- a/src/components/search-filter/types.ts
+++ b/src/components/search-filter/types.ts
@@ -14,11 +14,13 @@ export type SearchFilterProps<T extends SearchFilterItem = SearchFilterItem> = {
   placeholder?: string;
   items: T[];
   renderItem: (item: T) => ReactNode;
-  onItemSelect?: (item: T) => void;
+  onItemSelect?: (item?: T) => void;
+  selected?: T;
   isLoading?: boolean;
   emptyState?: ReactNode;
   isOpen?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
+  showReset?: boolean;
 };
 
 export type UserSearchFilterItem = SearchFilterItem & {

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -3,6 +3,9 @@
     "menu": {
       "newWindowLabelSuffix": " (neues Fenster)"
     },
+    "searchFilter": {
+      "reset": "Zurücksetzen"
+    },
     "share": {
       "copyLink": "Link kopieren",
       "ok": "OK",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -3,13 +3,16 @@
     "menu": {
       "newWindowLabelSuffix": " (new window)"
     },
+    "searchFilter": {
+      "reset": "Reset"
+    },
     "share": {
       "copyLink": "Copy link",
       "ok": "OK",
       "shareButton": "Share",
       "modalTitle": "Share folder",
       "modalAriaLabel": "Share modal",
-      
+
       "access": {
         "delete": "Remove access"
       },

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -3,6 +3,9 @@
     "menu": {
       "newWindowLabelSuffix": " (nueva ventana)"
     },
+    "searchFilter": {
+      "reset": "Restablecer"
+    },
     "share": {
       "copyLink": "Copiar enlace",
       "ok": "OK",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -3,6 +3,9 @@
     "menu": {
       "newWindowLabelSuffix": " (nouvelle fenêtre)"
     },
+    "searchFilter": {
+      "reset": "Réinitialiser"
+    },
     "share": {
       "copyLink": "Copier le lien",
       "ok": "OK",

--- a/src/locales/nl-NL.json
+++ b/src/locales/nl-NL.json
@@ -3,6 +3,9 @@
     "menu": {
       "newWindowLabelSuffix": " (nieuw venster)"
     },
+    "searchFilter": {
+      "reset": "Resetten"
+    },
     "share": {
       "copyLink": "Link kopiëren",
       "ok": "OK",


### PR DESCRIPTION
## Summary

Adds a built-in "Reset" row to `Filter` and `SearchFilter` so a selected value can be cleared from within the open dropdown.

- **Filter**: `showReset` (default `true`) renders a Reset row above the options once a value is selected; clicking it clears the selection without closing the menu.
- **SearchFilter**: takes a `selected` item and shows the same Reset row while set; `onItemSelect` now accepts an optional item to carry the reset.
- **Menu icons**: menu affordances (check / chevron / undo / search) now use `Icon` components with dedicated CSS classes instead of raw `material-icons` spans.

## Tests

- New e2e specs for the Filter and SearchFilter reset rows.
- Updated Filter specs to target the new icon CSS classes.


## Before
<img width="439" height="398" alt="Capture d’écran 2026-07-01 à 15 41 35" src="https://github.com/user-attachments/assets/0d470cbe-1c5a-462a-820a-2fd2ffe62ad4" />
<img width="403" height="384" alt="Capture d’écran 2026-07-01 à 15 41 39" src="https://github.com/user-attachments/assets/ba9d0fca-ac82-4b54-8df3-89e7c244f73b" />

# After
<img width="390" height="325" alt="Capture d’écran 2026-07-01 à 15 42 01" src="https://github.com/user-attachments/assets/9d8413a0-e16f-46ce-a05d-5cca1ac37e7a" />
<img width="348" height="356" alt="Capture d’écran 2026-07-01 à 15 41 56" src="https://github.com/user-attachments/assets/e0e411f3-aa8f-439f-bab8-e45cad9e1d3d" />
