### PR TITLE
🐛(ci) let the storybook base path reach the turbo task

### DIFF
--- a/packages/ui-components/.storybook/main.ts
+++ b/packages/ui-components/.storybook/main.ts
@@ -45,10 +45,14 @@ const config: StorybookConfig = {
     autodocs: "tag",
   },
   async viteFinal(viteConfig, { configType }) {
-    viteConfig.base =
-      configType === "PRODUCTION"
-        ? normalizeBasePath(process.env.STORYBOOK_BASE_PATH)
-        : "/";
+    if (configType === "PRODUCTION") {
+      const basePath = normalizeBasePath(process.env.STORYBOOK_BASE_PATH);
+      // Without a configured base path, keep the builder's relative default
+      // ("./") so the static build works from any subdirectory.
+      if (basePath !== "/") {
+        viteConfig.base = basePath;
+      }
+    }
     viteConfig.plugins = viteConfig.plugins?.filter((plugin) => {
       return !(
         typeof plugin === "object" &&

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
     "build-storybook": {
       "cache": false,
       "dependsOn": ["build"],
+      "env": ["STORYBOOK_BASE_PATH"],
       "outputs": []
     }
   }


### PR DESCRIPTION
## Summary

The deployed Storybook at https://suitenumerique.github.io/ui-kit/ loaded forever with 404s on every preview asset.

Two causes, both fixed:
- `turbo.json` did not declare `STORYBOOK_BASE_PATH` on the `build-storybook` task, and Turborepo 2 strict env mode strips undeclared variables — the value set by the Pages workflow never reached `storybook build`.
- `.storybook/main.ts` then forced `base: "/"` as fallback, overriding the vite builder's subpath-safe relative default (`./`). Assets were emitted as `/assets/…`, which 404s under `/ui-kit/`.

With the fix, a build with `STORYBOOK_BASE_PATH=/ui-kit` emits `/ui-kit/assets/…` and a plain build emits relative `./assets/…`.

## Testing

- `STORYBOOK_BASE_PATH=/ui-kit yarn build-storybook` → `iframe.html` references `/ui-kit/assets/…`
- `yarn build-storybook` → `iframe.html` references `./assets/…`

The Pages deployment will repair itself on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)