### PR TITLE
🐛(codemod) use published package ranges

### DIFF
--- a/.changeset/stable-components-release.md
+++ b/.changeset/stable-components-release.md
@@ -1,0 +1,5 @@
+---
+"@gouvfr-lasuite/ui-components": major
+---
+
+Publish the unified component library as the stable 1.0.0 release.

--- a/packages/ui-codemod/src/mappings.js
+++ b/packages/ui-codemod/src/mappings.js
@@ -11,6 +11,11 @@ export const PACKAGE_MAPPINGS = {
   "@gouvfr-lasuite/ui-kit": PACKAGES.components,
 };
 
+export const PACKAGE_RANGES = {
+  [PACKAGES.components]: "^1.0.0",
+  [PACKAGES.tokens]: "^3.1.0",
+};
+
 const EXACT_SPECIFIER_MAPPINGS = new Map([
   ["@gouvfr-lasuite/cunningham-react", PACKAGES.components],
   ["@gouvfr-lasuite/cunningham-react/style", `${PACKAGES.components}/style`],

--- a/packages/ui-codemod/src/transform.js
+++ b/packages/ui-codemod/src/transform.js
@@ -1,5 +1,5 @@
 import jscodeshift from "jscodeshift";
-import { mapSpecifier, PACKAGES, PACKAGE_MAPPINGS, sourceIsEnabled } from "./mappings.js";
+import { mapSpecifier, PACKAGES, PACKAGE_MAPPINGS, PACKAGE_RANGES, sourceIsEnabled } from "./mappings.js";
 
 const parsers = {
   ".js": "babel",
@@ -221,7 +221,7 @@ export function transformPackageJson(sourceText, filePath, options = {}) {
     if (!dependencies || typeof dependencies !== "object") continue;
     for (const [oldName, newName] of Object.entries(PACKAGE_MAPPINGS)) {
       if (!sourceIsEnabled(oldName, source) || !(oldName in dependencies)) continue;
-      if (!(newName in dependencies)) dependencies[newName] = "^1.0.0";
+      if (!(newName in dependencies)) dependencies[newName] = PACKAGE_RANGES[newName];
       delete dependencies[oldName];
       changed = true;
     }

--- a/packages/ui-codemod/tests/transform.test.js
+++ b/packages/ui-codemod/tests/transform.test.js
@@ -49,7 +49,7 @@ test("merges package dependencies and is idempotent", () => {
   const first = transformPackageJson(input, "package.json", { source: "all" });
   const second = transformPackageJson(first.output, "package.json", { source: "all" });
   assert.equal(JSON.parse(first.output).dependencies["@gouvfr-lasuite/ui-components"], "^1.0.0");
-  assert.equal(JSON.parse(first.output).dependencies["@gouvfr-lasuite/ui-tokens"], "^1.0.0");
+  assert.equal(JSON.parse(first.output).dependencies["@gouvfr-lasuite/ui-tokens"], "^3.1.0");
   assert.equal(second.changed, false);
 });
 
@@ -92,7 +92,7 @@ test("rewrites legacy @openfun styles and package.json dependencies", () => {
   } }, null, 2)}\n`, "package.json", { source: "all" });
   const dependencies = JSON.parse(pkg.output).dependencies;
   assert.equal(dependencies["@gouvfr-lasuite/ui-components"], "^1.0.0");
-  assert.equal(dependencies["@gouvfr-lasuite/ui-tokens"], "^1.0.0");
+  assert.equal(dependencies["@gouvfr-lasuite/ui-tokens"], "^3.1.0");
   assert.equal("@openfun/cunningham-react" in dependencies, false);
 });
 


### PR DESCRIPTION
The dependency migration assigned ^1.0.0 to every replacement package, but ui-components is published as 0.29.0 and ui-tokens as 3.1.0. This left migrated applications with ranges that cannot resolve the available releases.

Keep the default range next to each target package and cover both current and legacy package mappings in the transformation tests.