### PR TITLE
🐛(components) resolve the calendar hooks to a single react-aria copy

### DIFF
--- a/.changeset/calendar-single-import.md
+++ b/.changeset/calendar-single-import.md
@@ -1,5 +1,0 @@
----
-"@gouvfr-lasuite/ui-components": patch
----
-
-🐛(components) resolve the calendar hooks to a single react-aria copy

--- a/.changeset/calendar-single-import.md
+++ b/.changeset/calendar-single-import.md
@@ -1,0 +1,5 @@
+---
+"@gouvfr-lasuite/ui-components": patch
+---
+
+🐛(components) resolve the calendar hooks to a single react-aria copy

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,52 @@ export default tseslint.config(
     },
   },
   {
+    // The calendar and date picker hooks exchange per-render state through a
+    // WeakMap held in the module scope of @react-aria/calendar. Importing one
+    // of them through the react-aria umbrella instead resolves to a second
+    // copy in any consumer whose tree carries one, and the cell then reads a
+    // map the grid never wrote to. Types are erased, so they stay allowed.
+    files: [
+      "packages/ui-components/src/components/calendar/**/*.{ts,tsx}",
+      "packages/ui-components/src/components/forms/date-picker/**/*.{ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react-aria",
+              importNames: [
+                "useCalendar",
+                "useCalendarCell",
+                "useCalendarGrid",
+                "useRangeCalendar",
+                "useDateField",
+                "useDatePicker",
+                "useDateRangePicker",
+              ],
+              message:
+                "Import calendar and date picker hooks from @react-aria/calendar or @react-aria/datepicker so every hook resolves to one copy.",
+            },
+            {
+              name: "react-stately",
+              importNames: [
+                "useCalendarState",
+                "useRangeCalendarState",
+                "useDateFieldState",
+                "useDatePickerState",
+                "useDateRangePickerState",
+              ],
+              message:
+                "Import calendar and date picker state from @react-stately/calendar or @react-stately/datepicker so every hook resolves to one copy.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: [
       "packages/ui-components/**/*.stories.{ts,tsx}",
       "packages/ui-components/**/*.spec.{ts,tsx}",

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [UNRELEASED]
 
+## 1.1.2
+
+### Patch Changes
+
+- 🐛(components) resolve the calendar hooks to a single react-aria copy
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gouvfr-lasuite/ui-components",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/packages/ui-components/src/components/calendar/CalendarGrid.tsx
+++ b/packages/ui-components/src/components/calendar/CalendarGrid.tsx
@@ -6,7 +6,7 @@ import {
   startOfWeek,
   today,
 } from "@internationalized/date";
-import { useCalendarGrid } from "react-aria";
+import { useCalendarGrid } from "@react-aria/calendar";
 import { CalendarState, RangeCalendarState } from "@react-stately/calendar";
 import classNames from "classnames";
 import { CalendarCell } from ":/components/calendar/CalendarCell";


### PR DESCRIPTION
## Problem

`Calendar` imports its three react-aria hooks through two different names:

```
CalendarCell.tsx   useCalendarCell    @react-aria/calendar
CalendarAux.tsx    useCalendar        @react-aria/calendar
CalendarGrid.tsx   useCalendarGrid    react-aria          ← the odd one out
```

They exchange per-render state through `hookData`, a `WeakMap` held in module scope.
That works only while every hook is the same module instance. In a consumer whose tree
carries two copies of `@react-aria/calendar` the grid writes to one map and the cell
reads the other, so opening a date picker throws:

```
TypeError: Cannot destructure property 'ariaLabel' of 'hookData.get(...)' as it is undefined.
```

This repository resolves a single copy of everything, which is why the split is
invisible here — typecheck, unit tests, component tests and Storybook all pass with the
bug present. No test could have caught it, so the guard has to be static.

Drive hit this on the date filter after upgrading to 1.1.1.

## Changes

- `CalendarGrid.tsx` imports `useCalendarGrid` from `@react-aria/calendar`, so all the
  calendar hooks resolve to one copy.
- A `no-restricted-imports` rule blocks the calendar and date picker *hooks* from being
  imported through `react-aria` / `react-stately`. Type imports stay allowed, since
  types are erased and create no module instance.

The `@react-aria/*` pins are deliberately left exact. Relaxing them to `^` is worse, not
better: `^3.9.5` resolves to `@react-aria/calendar` 3.10.1, which is a re-export shim
requiring `react-aria` `^3.48.0`, and that pulls a second umbrella in beside the pinned
3.47.0 — 41 nested copies in a scratch install.

## Verification

Built this branch and installed the result into Drive's `node_modules`, leaving its
duplicated tree in place and removing the `resolutions` workaround it currently needs:

- published 1.1.1 — opening the picker throws the error above
- this branch — the calendar opens and a date is selected, no errors

Reverting the lint rule's target line reproduces the original import and fails `eslint`.
